### PR TITLE
Feat/create user

### DIFF
--- a/example/create_user_api_example.json
+++ b/example/create_user_api_example.json
@@ -1,4 +1,7 @@
 {
     "name": "Johnathan",
-    "email": "johnathan@example.com"
+    "email": "johnathan@example.com",
+    "age": 18,
+    "sex": -0.3,
+    "gender": 0.7
 }

--- a/src/adapter/controller/user.go
+++ b/src/adapter/controller/user.go
@@ -27,9 +27,15 @@ type UserController struct {
 	userRepositoryFactory UserRepositoryFactory
 }
 
+// 0が存在しないとして扱われるため数字型(int, float32)にvalidate:"required"を使用していない。(requiredがなくても型確認はされます。)
+// 数字型のものが未入力であれば0として扱われる
+// 0を存在する値とする場合にはカスタムバリデーションを使用する必要があり、カスタムバリデーションにはrouterで定義されたecho.New()を使用するため今回はカスタムバリデーションを使用しない。
 type UserRequestBody struct {
-	Name  string `json:"name" validate:"required"`
-	Email string `json:"email" validate:"required,email"`
+	Name   string  `json:"name" validate:"required"`
+	Email  string  `json:"email" validate:"required,email"`
+	Age    int     `json:"age"`
+	Sex    float32 `json:"sex"`
+	Gender float32 `json:"gender"`
 }
 
 func NewUserController(userDriverFactory UserDriverFactory, userOutputFactory UserOutputFactory, userInputFactory UserInputFactory, userRepositoryFactory UserRepositoryFactory) UserI {
@@ -49,7 +55,7 @@ func (uc *UserController) CreateUser(c echo.Context) error {
 	if err := c.Validate(&u); err != nil {
 		return c.JSON(http.StatusInternalServerError, err.(validator.ValidationErrors).Error())
 	}
-	user, err := model.NewUser(u.Name, u.Email)
+	user, err := model.NewUser(u.Name, u.Email, u.Age, u.Sex, u.Gender)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -73,7 +73,7 @@ func TestCreateUser(t *testing.T) {
 	c, rec := newRouter()
 	var expected error = nil
 	// デフォルトでリクエストメソッドがGETのため、POSTに変更。こういうPOSTリクエストが来たことにする
-	reqBody := `{"name":"noiman","email":"noiman@groovex.co.jp"}`
+	reqBody := `{"name":"noiman","email":"noiman@groovex.co.jp","age":10,"sex":0.4,"gender":-0.3}`
 	req := httptest.NewRequest(http.MethodPost, "/user", bytes.NewBufferString(reqBody))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c.SetRequest(req)

--- a/src/adapter/gateway/user.go
+++ b/src/adapter/gateway/user.go
@@ -22,8 +22,11 @@ func NewUserRepository(userDriver UserDriver) port.UserRepository {
 
 func (ug *UserGateway) Create(user *model.User) error {
 	dbUser := &db.User{
-		Name:  user.Name,
-		Email: user.Email,
+		Name:   user.Name,
+		Email:  user.Email,
+		Age:    user.Age,
+		Sex:    user.Sex,
+		Gender: user.Gender,
 	}
 	if err := ug.userDriver.CreateUser(dbUser); err != nil {
 		return err

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -25,8 +25,11 @@ func TestCreate(t *testing.T) {
 	mockUserRepository.On("CreateUser").Return(nil)
 	ug := &UserGateway{userDriver: mockUserRepository}
 	user := &model.User{
-		Name:  "noiman",
-		Email: "noiman@groovex.co.jp",
+		Name:   "noiman",
+		Email:  "noiman@groovex.co.jp",
+		Age:    35,
+		Sex:    1.0,
+		Gender: -0.5,
 	}
 
 	/* Act */

--- a/src/driver/db/user.go
+++ b/src/driver/db/user.go
@@ -14,6 +14,9 @@ type User struct {
 	Id        int `gorm:"primaryKey"`
 	Name      string
 	Email     string
+	Age       int
+	Sex       float32
+	Gender    float32
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/src/entity/user.go
+++ b/src/entity/user.go
@@ -31,9 +31,7 @@ func ageValid(age int) error {
 }
 
 func ageFormat(age int) int {
-	if age < 0 {
-		return 0
-	}
+	// ageValidで0未満はエラーとなるので0未満は扱わない。
 	if age >= 60 {
 		return 60
 	}
@@ -65,7 +63,7 @@ func NewUser(name string, email string, age int, sex float32, gender float32) (*
 	emailValidError := emailValid(email)
 	ageValidError := ageValid(age)
 	if err := errors.Join(emailValidError, ageValidError); err != nil {
-		return &User{}, err
+		return nil, err
 	}
 	// userの作成
 	user := &User{

--- a/src/entity/user.go
+++ b/src/entity/user.go
@@ -6,27 +6,74 @@ import (
 )
 
 type User struct {
-	Id    int
-	Name  string
-	Email string
+	Id     int
+	Name   string
+	Email  string
+	Age    int     // xx代として表記する(60代以上は全て60とする)
+	Sex    float32 // -1.0(男性)~1.0(女性)で表現する。中性、無回答は0となる。
+	Gender float32 // -1.0(男性)~1.0(女性)で表現する。中性、無回答は0となる。
 }
 
-func (u User) Valid() error {
-    emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-    re := regexp.MustCompile(emailRegex)
-    if !re.MatchString(u.Email) {
-        return errors.New("emailではありません")
-    }
+func emailValid(email string) error {
+	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
+	re := regexp.MustCompile(emailRegex)
+	if !re.MatchString(email) {
+		return errors.New("emailではありません")
+	}
 	return nil
 }
 
-func NewUser(name string, email string) (*User, error) {
-	user := &User{
-		Name:  name,
-		Email: email,
+func ageValid(age int) error {
+	if age < 0 {
+		return errors.New("年齢が0未満です。")
 	}
-	if err := user.Valid(); err != nil {
+	return nil
+}
+
+func ageFormat(age int) int {
+	if age < 0 {
+		return 0
+	}
+	if age >= 60 {
+		return 60
+	}
+	return (age / 10) * 10
+}
+
+func sexFormat(sex float32) float32 {
+	if sex < -1.0 {
+		return -1.0
+	}
+	if sex > 1.0 {
+		return 1.0
+	}
+	return sex
+}
+
+func genderFormat(gender float32) float32 {
+	if gender < -1.0 {
+		return -1.0
+	}
+	if gender > 1.0 {
+		return 1.0
+	}
+	return gender
+}
+
+func NewUser(name string, email string, age int, sex float32, gender float32) (*User, error) {
+	// バリデーションのチェック
+	emailValidError := emailValid(email)
+	ageValidError := ageValid(age)
+	if err := errors.Join(emailValidError, ageValidError); err != nil {
 		return &User{}, err
+	}
+	// userの作成
+	user := &User{
+		Name:   name,
+		Email:  email,
+		Age:    ageFormat(age),
+		Sex:    sexFormat(sex),
+		Gender: genderFormat(gender),
 	}
 	return user, nil
 }

--- a/src/usecase/interactor/user_test.go
+++ b/src/usecase/interactor/user_test.go
@@ -29,7 +29,7 @@ func (m *MockUserOutputPort) OutputCreateResult() error {
 func TestCreateUser(t *testing.T) {
 	/* Arrange */
 	var expected error = nil
-	user := &model.User{Id: 1, Name: "natori", Email: "test@example.com"}
+	user := &model.User{Id: 1, Name: "natori", Email: "test@example.com", Age: 52, Sex: -0.2, Gender: 1.0}
 
 	mockUserRepository := new(MockUserRepository)
 	mockUserRepository.On("Create").Return(nil)


### PR DESCRIPTION
userを作成するAPIです。
nameとemailのカラムでユーザを作っていましたが、そこにage(年齢), sex(体の性別), gender(心の性別)を追加してvalidate、formatをかけて保存するようにしています。

### 注意点
- requiredをかけていないカラムが存在する
- 全ての入力エラーを同時に返さない

**requiredをかけていないカラムが存在する**
ここのコメントアウトにもありますが、echo.Contextのvalidetionのrequiredは数字型のカラム(age,sex,gender)には0が無効な値となる観点から適応させていません。
https://github.com/RinachanBoard31/clean-storemap-api/blob/9c5776abd5db9f2d465b5d3a43306c0c34c434f2/src/adapter/controller/user.go#L30-L39

**全ての入力エラーを同時に返さない**
異なる種類のエラーを各々確認してエラーがあればすぐにreturnしているため、存在する全てのエラーを同時に返さない設計になっています。
例: nameが空で``Name   string  `json:"name" validate:"required"` ``に引っかかった場合にはageが有効な値かを確認する前にerrorが返され、ageについてはエラーが出ているのかがわからない。
https://github.com/RinachanBoard31/clean-storemap-api/blob/9c5776abd5db9f2d465b5d3a43306c0c34c434f2/src/adapter/controller/user.go#L51-L61