### PR TITLE
add-location-to-near-stores: /stores/opening-hours のレスポンスに location を追加

### DIFF
--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -5,6 +5,7 @@ import (
 	db "clean-storemap-api/src/driver/db"
 	model "clean-storemap-api/src/entity"
 	"clean-storemap-api/src/usecase/port"
+	"fmt"
 	"strings"
 )
 
@@ -41,6 +42,10 @@ func (sg *StoreGateway) GetAll() ([]*model.Store, error) {
 			Name:                v.Name,
 			RegularOpeningHours: v.RegularOpeningHours,
 			PriceLevel:          v.PriceLevel,
+			Location: model.Location{
+				Lat: v.Latitude,
+				Lng: v.Longitude,
+			},
 		})
 	}
 	return stores, nil
@@ -58,6 +63,10 @@ func (sg *StoreGateway) GetNearStores() ([]*model.Store, error) {
 			Name:                v.Name,
 			RegularOpeningHours: strings.Join(v.RegularOpeningHours, ", "),
 			PriceLevel:          v.PriceLevel,
+			Location: model.Location{
+				Lat: fmt.Sprintf("%f", v.Location.Lat),
+				Lng: fmt.Sprintf("%f", v.Location.Lng),
+			},
 		})
 	}
 	return stores, nil

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -17,12 +17,16 @@ func makeDummyDbStores() ([]*db.Store, error) {
 		Name:                "UEC cafe",
 		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 		PriceLevel:          "PRICE_LEVEL_MODERATE",
+		Latitude:            "35.713",
+		Longitude:           "139.762",
 	})
 	dummyStores = append(dummyStores, &db.Store{
 		Id:                  "Id002",
 		Name:                "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
 		PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
+		Latitude:            "35.714",
+		Longitude:           "139.763",
 	})
 	return dummyStores, nil
 }
@@ -34,12 +38,14 @@ func makeDummyApiStores() ([]*api.Store, error) {
 		Name:                "UEC cafe",
 		RegularOpeningHours: []string{"Sat: 06:00 - 22:00", "Sun: 06:00 - 22:00"},
 		PriceLevel:          "PRICE_LEVEL_MODERATE",
+		Location:            api.Location{Lat: 35.713, Lng: 139.762},
 	})
 	dummyStores = append(dummyStores, &api.Store{
 		Id:                  "Id002",
 		Name:                "UEC restaurant",
 		RegularOpeningHours: []string{"Sat: 11:00 - 20:00", "Sun: 11:00 - 20:00"},
 		PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
+		Location:            api.Location{Lat: 35.714, Lng: 139.763},
 	})
 	return dummyStores, nil
 }
@@ -75,6 +81,7 @@ func TestGetAll(t *testing.T) {
 			Name:                "UEC cafe",
 			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 			PriceLevel:          "PRICE_LEVEL_MODERATE",
+			Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 		},
 	)
 	stores = append(
@@ -84,6 +91,7 @@ func TestGetAll(t *testing.T) {
 			Name:                "UEC restaurant",
 			RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
 			PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
+			Location:            model.Location{Lat: "35.714", Lng: "139.763"},
 		},
 	)
 	expected := stores
@@ -111,12 +119,14 @@ func TestGetNearStores(t *testing.T) {
 			Name:                "UEC cafe",
 			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 			PriceLevel:          "PRICE_LEVEL_MODERATE",
+			Location:            model.Location{Lat: "35.713000", Lng: "139.762000"},
 		},
 		&model.Store{
 			Id:                  "Id002",
 			Name:                "UEC restaurant",
 			RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
 			PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
+			Location:            model.Location{Lat: "35.714000", Lng: "139.763000"},
 		},
 	)
 	expected := stores

--- a/src/adapter/presenter/store.go
+++ b/src/adapter/presenter/store.go
@@ -20,11 +20,17 @@ type StoreOutputJson struct {
 	Stores []storeForPresenter `json:"stores"`
 }
 
+type locationForPresenter struct {
+	Latitude  string `json:"latitude"`
+	Longitude string `json:"longitude"`
+}
+
 type storeForPresenter struct {
-	Id                  string `json:"id"`
-	Name                string `json:"name"`
-	RegularOpeningHours string `json:"regularOpeningHours"`
-	PriceLevel          string `json:"priceLevel"`
+	Id                  string               `json:"id"`
+	Name                string               `json:"name"`
+	RegularOpeningHours string               `json:"regularOpeningHours"`
+	PriceLevel          string               `json:"priceLevel"`
+	Location            locationForPresenter `json:"location"`
 }
 
 func (sp *StorePresenter) OutputAllStores(stores []*model.Store) error {
@@ -35,6 +41,10 @@ func (sp *StorePresenter) OutputAllStores(stores []*model.Store) error {
 			Name:                v.Name,
 			RegularOpeningHours: v.RegularOpeningHours,
 			PriceLevel:          v.PriceLevel,
+			Location: locationForPresenter{
+				Latitude:  v.Location.Lat,
+				Longitude: v.Location.Lng,
+			},
 		})
 	}
 	output_json := &StoreOutputJson{Stores: json_stores}

--- a/src/adapter/presenter/store_test.go
+++ b/src/adapter/presenter/store_test.go
@@ -22,7 +22,7 @@ func newRouter() (echo.Context, *httptest.ResponseRecorder) {
 
 func TestOutputAllStores(t *testing.T) {
 	/* Arrange */
-	expected := "{\"stores\":[{\"id\":\"Id001\",\"name\":\"UEC cafe\",\"regularOpeningHours\":\"Sat: 06:00 - 22:00, Sun: 06:00 - 22:00\",\"priceLevel\":\"PRICE_LEVEL_MODERATE\"}]}\n"
+	expected := "{\"stores\":[{\"id\":\"Id001\",\"name\":\"UEC cafe\",\"regularOpeningHours\":\"Sat: 06:00 - 22:00, Sun: 06:00 - 22:00\",\"priceLevel\":\"PRICE_LEVEL_MODERATE\",\"location\":{\"latitude\":\"35.713\",\"longitude\":\"139.762\"}}]}\n"
 	stores := make([]*model.Store, 0)
 	stores = append(
 		stores,
@@ -31,6 +31,7 @@ func TestOutputAllStores(t *testing.T) {
 			Name:                "UEC cafe",
 			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 			PriceLevel:          "PRICE_LEVEL_MODERATE",
+			Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 		},
 	)
 	c, rec := newRouter()

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -16,6 +16,8 @@ type Store struct {
 	Name                string
 	RegularOpeningHours string
 	PriceLevel          string
+	Latitude            string
+	Longitude           string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }

--- a/src/entity/store.go
+++ b/src/entity/store.go
@@ -1,8 +1,14 @@
 package model
 
+type Location struct {
+	Lat string
+	Lng string
+}
+
 type Store struct {
 	Id                  string
 	Name                string
 	RegularOpeningHours string
 	PriceLevel          string
+	Location            Location
 }

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -42,6 +42,7 @@ func TestGetStores(t *testing.T) {
 			Name:                "UEC cafe",
 			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 			PriceLevel:          "PRICE_LEVEL_MODERATE",
+			Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 		},
 	)
 
@@ -77,6 +78,7 @@ func TestGetNearStores(t *testing.T) {
 			Name:                "UEC cafe",
 			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 			PriceLevel:          "PRICE_LEVEL_MODERATE",
+			Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 		},
 	)
 


### PR DESCRIPTION
clean-storemap-web で Google Map 上に Marker を置くのに座標が必要なため