### PR TITLE
OAuthを用いた仮登録

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ docker compose -f environments/docker-compose.yml up -d
 #### 認証情報の追加
 1. 「アプリケーションの種類」をウェブアプリケーションにする
 2. 「承認済みの JavaScript 生成元」をバックエンドのものにする(http://localhost:PORT番号)
-3. 「承認済みのリダイレクト URI」をバックエンドのものにする(http://localhost:PORT番号/signup)
+3. 「承認済みのリダイレクト URI」をバックエンドのものにする(http://localhost:PORT番号/auth/signup)
 4. 「クライアント ID」と「クライアント シークレット」を環境変数にセットする
 5. 環境変数のBACKEND_URLに"http://localhost:PORT番号"をセットする
 

--- a/src/adapter/controller/user.go
+++ b/src/adapter/controller/user.go
@@ -15,6 +15,7 @@ type UserI interface {
 	CreateUser(c echo.Context) error
 	LoginUser(c echo.Context) error
 	GetAuthUrl(c echo.Context) error
+	SignupWithAuth(c echo.Context) error
 }
 
 type UserOutputFactory func(echo.Context) port.UserOutputPort
@@ -95,8 +96,14 @@ func (uc *UserController) LoginUser(c echo.Context) error {
 	}
 	return nil
 }
+
 func (uc *UserController) GetAuthUrl(c echo.Context) error {
 	return uc.newUserInputPort(c).GetAuthUrl()
+}
+
+func (uc *UserController) SignupWithAuth(c echo.Context) error {
+	codeParameter := c.QueryParam("code") // パラメータの取得
+	return uc.newUserInputPort(c).SignupDraft(codeParameter)
 }
 
 /* ここでpresenterにecho.Contextを渡している！起爆！！！（遅延） */

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -70,7 +70,7 @@ func (m *MockUserOutputFactoryFuncObject) OutputLoginResult() error {
 	return args.Error(0)
 }
 
-func (m *MockUserOutputFactoryFuncObject) OutputSignupWithAuth() error {
+func (m *MockUserOutputFactoryFuncObject) OutputSignupWithAuth(int) error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -35,9 +35,9 @@ type MockUserInputFactoryFuncObject struct {
 	mock.Mock
 }
 
-func (m *MockUserDriverFactory) CreateUser(*db.User) error {
+func (m *MockUserDriverFactory) CreateUser(*db.User) (*db.User, error) {
 	args := m.Called()
-	return args.Error(0)
+	return args.Get(0).(*db.User), args.Error(1)
 }
 
 func (m *MockUserDriverFactory) FindByEmail(string) error {
@@ -79,9 +79,9 @@ func mockUserOutputFactoryFunc(c echo.Context) port.UserOutputPort {
 	return &MockUserOutputFactoryFuncObject{}
 }
 
-func (m *MockUserRepositoryFactoryFuncObject) Create(*model.User) error {
+func (m *MockUserRepositoryFactoryFuncObject) Create(*model.User) (*model.User, error) {
 	args := m.Called()
-	return args.Error(0)
+	return args.Get(0).(*model.User), args.Error(1)
 }
 
 func (m *MockUserRepositoryFactoryFuncObject) GenerateAuthUrl() string {

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -75,6 +75,11 @@ func (m *MockUserOutputFactoryFuncObject) OutputSignupWithAuth(int) error {
 	return args.Error(0)
 }
 
+func (m *MockUserOutputFactoryFuncObject) OutputAlreadySignedup() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func mockUserOutputFactoryFunc(c echo.Context) port.UserOutputPort {
 	return &MockUserOutputFactoryFuncObject{}
 }

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -50,6 +50,11 @@ func (m *MockGoogleOAuthDriverFactory) GenerateUrl() string {
 	return args.Get(0).(string)
 }
 
+func (m *MockGoogleOAuthDriverFactory) GetEmail(string) (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
 func (m *MockUserOutputFactoryFuncObject) OutputCreateResult() error {
 	args := m.Called()
 	return args.Error(0)
@@ -61,6 +66,11 @@ func (m *MockUserOutputFactoryFuncObject) OutputAuthUrl(url string) error {
 }
 
 func (m *MockUserOutputFactoryFuncObject) OutputLoginResult() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockUserOutputFactoryFuncObject) OutputSignupWithAuth() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -84,6 +94,11 @@ func (m *MockUserRepositoryFactoryFuncObject) FindBy(*model.UserCredentials) err
 	return args.Error(0)
 }
 
+func (m *MockUserRepositoryFactoryFuncObject) GetUserInfoWithAuthCode(string) (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
 func mockUserRepositoryFactoryFunc(userDriver gateway.UserDriver, googleOAuthDriver gateway.GoogleOAuthDriver) port.UserRepository {
 	return &MockUserRepositoryFactoryFuncObject{}
 }
@@ -93,16 +108,17 @@ func (m *MockUserInputFactoryFuncObject) CreateUser(*model.User) error {
 	return args.Error(0)
 }
 
-
-
-
-
 func (m *MockUserInputFactoryFuncObject) GetAuthUrl() error {
-  args := m.Called()
+	args := m.Called()
 	return args.Error(0)
 }
 
 func (m *MockUserInputFactoryFuncObject) LoginUser(*model.UserCredentials) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockUserInputFactoryFuncObject) SignupDraft(string) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -160,7 +176,6 @@ func TestLoginUser(t *testing.T) {
 	// Driverだけは実体が必要
 	mockUserDriverFactory := new(MockUserDriverFactory)
 	mockUserDriverFactory.On("FindByEmail").Return(true)
-
 
 	// InputPortのLoginUserのモックを作成
 	uc := &UserController{
@@ -220,3 +235,38 @@ func TestGetAuthUrl(t *testing.T) {
 	mockUserInputFactoryFuncObject.AssertNumberOfCalls(t, "GetAuthUrl", 1)
 }
 
+func TestSignupWithAuth(t *testing.T) {
+	/* Arrange */
+	c, _ := newRouter()
+	var expected error = nil
+	reqBody := `{"code":"123456"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/signup", bytes.NewBufferString(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c.SetRequest(req)
+
+	// OAuth用(関数が実行されるわけではないので、mockの戻り値を設定しない)
+	mockGoogleOAuthDriverFactory := new(MockGoogleOAuthDriverFactory)
+
+	// DB用(関数が実行されるわけではないので、mockの戻り値を設定しない)
+	mockUserDriverFactory := new(MockUserDriverFactory)
+
+	uc := &UserController{
+		googleOAuthDriverFactory: mockGoogleOAuthDriverFactory,
+		userDriverFactory:        mockUserDriverFactory,
+		userOutputFactory:        mockUserOutputFactoryFunc,
+		userRepositoryFactory:    mockUserRepositoryFactoryFunc,
+	}
+
+	mockUserInputFactoryFuncObject := new(MockUserInputFactoryFuncObject)
+	mockUserInputFactoryFuncObject.On("SignupDraft").Return(nil)
+	uc.userInputFactory = func(repository port.UserRepository, output port.UserOutputPort) port.UserInputPort {
+		return mockUserInputFactoryFuncObject
+	}
+
+	/* Act */
+	actual := uc.SignupWithAuth(c)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockUserInputFactoryFuncObject.AssertNumberOfCalls(t, "SignupDraft", 1)
+}

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -83,7 +83,10 @@ func (m *MockUserRepositoryFactoryFuncObject) Create(*model.User) (*model.User, 
 	args := m.Called()
 	return args.Get(0).(*model.User), args.Error(1)
 }
-
+func (m *MockUserRepositoryFactoryFuncObject) Exist(*model.User) error {
+	args := m.Called()
+	return args.Error(0)
+}
 func (m *MockUserRepositoryFactoryFuncObject) GenerateAuthUrl() string {
 	args := m.Called()
 	return args.Get(0).(string)

--- a/src/adapter/gateway/user.go
+++ b/src/adapter/gateway/user.go
@@ -45,6 +45,13 @@ func (ug *UserGateway) Create(user *model.User) (*model.User, error) {
 	return user, nil
 }
 
+func (ug *UserGateway) Exist(user *model.User) error {
+	if err := ug.userDriver.FindByEmail(user.Email); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (ug *UserGateway) FindBy(user *model.UserCredentials) error {
 	if err := ug.userDriver.FindByEmail(user.Email); err != nil {
 		return err

--- a/src/adapter/gateway/user.go
+++ b/src/adapter/gateway/user.go
@@ -18,6 +18,7 @@ type UserDriver interface {
 
 type GoogleOAuthDriver interface {
 	GenerateUrl() string
+	GetEmail(string) (string, error)
 }
 
 func NewUserRepository(userDriver UserDriver, googleOAuthDriver GoogleOAuthDriver) port.UserRepository {
@@ -49,4 +50,12 @@ func (ug *UserGateway) FindBy(user *model.UserCredentials) error {
 }
 func (ug *UserGateway) GenerateAuthUrl() string {
 	return ug.googleOAuthDriver.GenerateUrl()
+}
+
+func (ug *UserGateway) GetUserInfoWithAuthCode(code string) (string, error) {
+	email, err := ug.googleOAuthDriver.GetEmail(code)
+	if err != nil {
+		return "", err
+	}
+	return email, nil
 }

--- a/src/adapter/gateway/user.go
+++ b/src/adapter/gateway/user.go
@@ -12,7 +12,7 @@ type UserGateway struct {
 }
 
 type UserDriver interface {
-	CreateUser(*db.User) error
+	CreateUser(*db.User) (*db.User, error)
 	FindByEmail(string) error
 }
 
@@ -28,7 +28,7 @@ func NewUserRepository(userDriver UserDriver, googleOAuthDriver GoogleOAuthDrive
 	}
 }
 
-func (ug *UserGateway) Create(user *model.User) error {
+func (ug *UserGateway) Create(user *model.User) (*model.User, error) {
 	dbUser := &db.User{
 		Name:   user.Name,
 		Email:  user.Email,
@@ -36,10 +36,13 @@ func (ug *UserGateway) Create(user *model.User) error {
 		Sex:    user.Sex,
 		Gender: user.Gender,
 	}
-	if err := ug.userDriver.CreateUser(dbUser); err != nil {
-		return err
+
+	dbUser, err := ug.userDriver.CreateUser(dbUser)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	user.Id = dbUser.Id // createが成功していればidを取得できるのでセットする
+	return user, nil
 }
 
 func (ug *UserGateway) FindBy(user *model.UserCredentials) error {

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -27,6 +27,11 @@ func (m *MockUserRepository) GenerateUrl() string {
 	return args.Get(0).(string)
 }
 
+func (m *MockUserRepository) GetEmail(string) (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
 func TestCreate(t *testing.T) {
 	/* Arrange */
 	var expected error = nil
@@ -86,4 +91,23 @@ func TestGenerateAuthUrl(t *testing.T) {
 	/* Assert */
 	assert.Equal(t, expected, actual)
 	mockUserRepository.AssertNumberOfCalls(t, "GenerateUrl", 1)
+}
+
+func TestGetUserInfoWithAuthCode(t *testing.T) {
+	/* Arrange */
+	code := ""
+	email := "sample@example.com"
+	expected := email
+	mockUserRepository := new(MockUserRepository)
+	mockUserRepository.On("GetEmail").Return(email, nil)
+	ug := &UserGateway{
+		googleOAuthDriver: mockUserRepository,
+	}
+
+	/* Act */
+	actual, _ := ug.GetUserInfoWithAuthCode(code)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockUserRepository.AssertNumberOfCalls(t, "GetEmail", 1)
 }

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -65,6 +65,31 @@ func TestCreate(t *testing.T) {
 	mockUserRepository.AssertNumberOfCalls(t, "CreateUser", 1)
 }
 
+func TestExist(t *testing.T) {
+	/* Arrange */
+	user := &model.User{
+		Name:   "noiman",
+		Email:  "noiman@groovex.co.jp",
+		Age:    35,
+		Sex:    1.0,
+		Gender: -0.5,
+	}
+	var expected error = nil
+
+	mockUserRepository := new(MockUserRepository)
+	mockUserRepository.On("FindByEmail").Return(nil)
+	ug := &UserGateway{userDriver: mockUserRepository}
+
+	/* Act */
+	actual := ug.Exist(user)
+
+	/* Assert */
+	// 返り値が正しいこと
+	assert.Equal(t, expected, actual)
+	// userDriver.CreateUser()が1回呼ばれること
+	mockUserRepository.AssertNumberOfCalls(t, "FindByEmail", 1)
+}
+
 func TestFindBy(t *testing.T) {
 	/* Arrange */
 	var expected error = nil

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -13,9 +13,9 @@ type MockUserRepository struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) CreateUser(*db.User) error {
+func (m *MockUserRepository) CreateUser(*db.User) (*db.User, error) {
 	args := m.Called()
-	return args.Error(0)
+	return args.Get(0).(*db.User), args.Error(1)
 }
 
 func (m *MockUserRepository) FindByEmail(string) error {
@@ -34,10 +34,6 @@ func (m *MockUserRepository) GetEmail(string) (string, error) {
 
 func TestCreate(t *testing.T) {
 	/* Arrange */
-	var expected error = nil
-	mockUserRepository := new(MockUserRepository)
-	mockUserRepository.On("CreateUser").Return(nil)
-	ug := &UserGateway{userDriver: mockUserRepository}
 	user := &model.User{
 		Name:   "noiman",
 		Email:  "noiman@groovex.co.jp",
@@ -45,9 +41,22 @@ func TestCreate(t *testing.T) {
 		Sex:    1.0,
 		Gender: -0.5,
 	}
+	dbUser := &db.User{
+		Id:     1,
+		Name:   user.Name,
+		Email:  user.Email,
+		Age:    user.Age,
+		Sex:    user.Sex,
+		Gender: user.Gender,
+	}
+	expected := user
+
+	mockUserRepository := new(MockUserRepository)
+	mockUserRepository.On("CreateUser").Return(dbUser, nil)
+	ug := &UserGateway{userDriver: mockUserRepository}
 
 	/* Act */
-	actual := ug.Create(user)
+	actual, _ := ug.Create(user)
 
 	/* Assert */
 	// 返り値が正しいこと

--- a/src/adapter/presenter/user.go
+++ b/src/adapter/presenter/user.go
@@ -3,6 +3,7 @@ package presenter
 import (
 	"clean-storemap-api/src/usecase/port"
 	"net/http"
+	"os"
 
 	"github.com/labstack/echo/v4"
 )
@@ -24,5 +25,10 @@ func (up *UserPresenter) OutputLoginResult() error {
 }
 
 func (up *UserPresenter) OutputAuthUrl(url string) error {
+	return up.c.Redirect(http.StatusFound, url)
+}
+
+func (up *UserPresenter) OutputSignupWithAuth() error {
+	url := os.Getenv("BACKEND_URL") + "/inputUserInfo" // 認証以外のユーザ情報を入力するページ
 	return up.c.Redirect(http.StatusFound, url)
 }

--- a/src/adapter/presenter/user.go
+++ b/src/adapter/presenter/user.go
@@ -4,6 +4,7 @@ import (
 	"clean-storemap-api/src/usecase/port"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 )
@@ -28,7 +29,7 @@ func (up *UserPresenter) OutputAuthUrl(url string) error {
 	return up.c.Redirect(http.StatusFound, url)
 }
 
-func (up *UserPresenter) OutputSignupWithAuth() error {
-	url := os.Getenv("BACKEND_URL") + "/inputUserInfo" // 認証以外のユーザ情報を入力するページ
+func (up *UserPresenter) OutputSignupWithAuth(id int) error {
+	url := os.Getenv("FRONT_URL") + "/editUser" + "?id=" + strconv.Itoa(id) // 認証以外のユーザ情報を入力するページ
 	return up.c.Redirect(http.StatusFound, url)
 }

--- a/src/adapter/presenter/user.go
+++ b/src/adapter/presenter/user.go
@@ -33,3 +33,8 @@ func (up *UserPresenter) OutputSignupWithAuth(id int) error {
 	url := os.Getenv("FRONT_URL") + "/editUser" + "?id=" + strconv.Itoa(id) // 認証以外のユーザ情報を入力するページ
 	return up.c.Redirect(http.StatusFound, url)
 }
+
+func (up *UserPresenter) OutputAlreadySignedup() error {
+	url := os.Getenv("FRONT_URL") // すでに登録済みの場合はトップページにリダイレクト
+	return up.c.Redirect(http.StatusFound, url)
+}

--- a/src/adapter/presenter/user_test.go
+++ b/src/adapter/presenter/user_test.go
@@ -2,6 +2,7 @@ package presenter
 
 import (
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,17 +60,23 @@ func TestOutputAuthUrl(t *testing.T) {
 }
 func TestOutputSignupWithAuth(t *testing.T) {
 	/* Arrange */
+	var id int = 1
+	requestPath := "/editUser"
+	queryParameter := "id=" + strconv.Itoa(id)
+
 	var expected error = nil
 	c, rec := newRouter()
 	up := &UserPresenter{c: c}
 
 	/* Act */
-	actual := up.OutputSignupWithAuth()
+	actual := up.OutputSignupWithAuth(id)
 
 	/* Assert */
 	// up.OutputLoginResultがJSONを返すこと
 	if assert.NoError(t, actual) {
 		assert.Equal(t, http.StatusFound, rec.Code)
+		assert.Contains(t, rec.HeaderMap["Location"][0], requestPath)
+		assert.Contains(t, rec.HeaderMap["Location"][0], queryParameter)
 		assert.Equal(t, expected, actual)
 	}
 }

--- a/src/adapter/presenter/user_test.go
+++ b/src/adapter/presenter/user_test.go
@@ -57,3 +57,19 @@ func TestOutputAuthUrl(t *testing.T) {
 		assert.Equal(t, expected, rec.HeaderMap["Location"][0])
 	}
 }
+func TestOutputSignupWithAuth(t *testing.T) {
+	/* Arrange */
+	var expected error = nil
+	c, rec := newRouter()
+	up := &UserPresenter{c: c}
+
+	/* Act */
+	actual := up.OutputSignupWithAuth()
+
+	/* Assert */
+	// up.OutputLoginResultがJSONを返すこと
+	if assert.NoError(t, actual) {
+		assert.Equal(t, http.StatusFound, rec.Code)
+		assert.Equal(t, expected, actual)
+	}
+}

--- a/src/driver/db/user.go
+++ b/src/driver/db/user.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"time"
 )
 
@@ -32,10 +33,11 @@ func (dbu *DbUserDriver) CreateUser(user *User) (*User, error) {
 
 func (dbu *DbUserDriver) FindByEmail(email string) error {
 	var user []*User
-	// 一致するemailがあるかを確認する
-	result := DB.Where("email = ?", email).First(&user)
-	if err := result.Error; err != nil {
-		return err
+	// Firstだと存在しない場合にサーバー側でエラーが発生してしまうため、Findでエラーを発生しないようにしている
+	result := DB.Where("email = ?", email).Find(&user)
+	// 存在しない場合にエラーは発生しないので、エラーを作成する
+	if result.RowsAffected == 0 {
+		return errors.New("user is not found")
 	}
 	return nil
 }

--- a/src/driver/db/user.go
+++ b/src/driver/db/user.go
@@ -13,7 +13,7 @@ func NewUserDriver() *DbUserDriver {
 type User struct {
 	Id        int `gorm:"primaryKey"`
 	Name      string
-	Email     string
+	Email     string `gorm:"unique"`
 	Age       int
 	Sex       float32
 	Gender    float32

--- a/src/driver/db/user.go
+++ b/src/driver/db/user.go
@@ -21,12 +21,13 @@ type User struct {
 	UpdatedAt time.Time
 }
 
-func (dbu *DbUserDriver) CreateUser(user *User) error {
-	err := DB.Create(&user).Error
+func (dbu *DbUserDriver) CreateUser(user *User) (*User, error) {
+	result := DB.Create(&user)
+	err := result.Error
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return user, err
 }
 
 func (dbu *DbUserDriver) FindByEmail(email string) error {

--- a/src/driver/oauth/google.go
+++ b/src/driver/oauth/google.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"os"
 
 	"github.com/coreos/go-oidc"
@@ -14,20 +15,63 @@ func NewGoogleOAuthDriver() *GoogleOAuthDriver {
 	return &GoogleOAuthDriver{}
 }
 
-func (oauth *GoogleOAuthDriver) GenerateUrl() string {
+func newGoogleOauthConfig() *oauth2.Config {
 	// Google認証を行うためのリダイレクト先のURL
-	redirectURL := os.Getenv("BACKEND_URL") + "/signup"
-
+	redirectURL := os.Getenv("BACKEND_URL") + "/auth/signup"
 	clientID := os.Getenv("GOOGLE_CLIENT_ID")
 	clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
-	//	認証情報を取得
-	config := &oauth2.Config{
+	conf := &oauth2.Config{
+		RedirectURL:  redirectURL,
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		RedirectURL:  redirectURL,
+		Scopes:       []string{oidc.ScopeOpenID, "email"}, // emailを取得するためのスコープ
 		Endpoint:     google.Endpoint,
-		Scopes:       []string{oidc.ScopeOpenID, "email"},
 	}
+	return conf
+}
+
+func (oauth *GoogleOAuthDriver) GenerateUrl() string {
+	//	認証情報を取得
+	config := newGoogleOauthConfig()
 	// URLの生成
 	return config.AuthCodeURL("state", oauth2.AccessTypeOffline)
+}
+
+// GoogleのOAuth認証を行い、ユーザー情報を取得する
+func getProfile(code string) (map[string]interface{}, error) {
+	config := newGoogleOauthConfig()
+	ctx := context.Background()
+	// 認証情報を取得
+	oauth2Token, err := config.Exchange(ctx, code)
+	if err != nil {
+		return make(map[string]interface{}), err
+	}
+	// IDトークンの取得
+	rawIdToken, ok := oauth2Token.Extra("id_token").(string)
+	if !ok {
+		return make(map[string]interface{}), err
+	}
+	provider, err := oidc.NewProvider(context.Background(), "https://accounts.google.com")
+	if err != nil {
+		return make(map[string]interface{}), err
+	}
+	// IDトークンの検証
+	idToken, err := provider.Verifier(&oidc.Config{ClientID: config.ClientID}).Verify(ctx, rawIdToken)
+	if err != nil {
+		return make(map[string]interface{}), err
+	}
+	// ユーザー情報の取得
+	var profile map[string]interface{}
+	if err := idToken.Claims(&profile); err != nil {
+		return make(map[string]interface{}), err
+	}
+	return profile, nil
+}
+
+func (oauth *GoogleOAuthDriver) GetEmail(code string) (string, error) {
+	profile, err := getProfile(code)
+	if err != nil {
+		return "", err
+	}
+	return profile["email"].(string), nil
 }

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -44,7 +44,8 @@ func (router *Router) Serve(ctx context.Context) {
 	router.echo.GET("/stores/opening-hours", router.storeController.GetNearStores)
 	router.echo.POST("/user", router.userController.CreateUser)
 	router.echo.POST("/login", router.userController.LoginUser)
-	router.echo.GET("/auth", router.userController.GetAuthUrl) // Google認証用のURLを取得し返す(ユーザの登録はsignupで行う)
-	// router.echo.POST("/signup", router.userController.SignUp) // Google認証後のユーザー登録(未実装)
+	router.echo.GET("/auth", router.userController.GetAuthUrl)            // Google認証用のURLを取得し返す
+	router.echo.GET("/auth/signup", router.userController.SignupWithAuth) // ユーザの認証を確認し仮登録する(本登録は未実装,UpdateUserで行う)
+	// router.echo.PATCH("/user", router.userController.UpdateUser)
 	router.echo.Logger.Fatal(router.echo.Start(":8080"))
 }

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -42,7 +42,7 @@ func NewRouter(echo *echo.Echo, storeController controller.StoreI, userControlle
 func (router *Router) Serve(ctx context.Context) {
 	router.echo.GET("/", router.storeController.GetStores)
 	router.echo.GET("/stores/opening-hours", router.storeController.GetNearStores)
-	router.echo.POST("/user", router.userController.CreateUser)
+	router.echo.POST("/user", router.userController.CreateUser) // こっちは時期に使わなくなります。
 	router.echo.POST("/login", router.userController.LoginUser)
 	router.echo.GET("/auth", router.userController.GetAuthUrl)            // Google認証用のURLを取得し返す
 	router.echo.GET("/auth/signup", router.userController.SignupWithAuth) // ユーザの認証を確認し仮登録する(本登録は未実装,UpdateUserで行う)

--- a/src/usecase/interactor/user.go
+++ b/src/usecase/interactor/user.go
@@ -18,7 +18,7 @@ func NewUserInputPort(userRepository port.UserRepository, userOutputPort port.Us
 }
 
 func (ui *UserInteractor) CreateUser(user *model.User) error {
-	if err := ui.userRepository.Create(user); err != nil {
+	if _, err := ui.userRepository.Create(user); err != nil {
 		return err
 	}
 	if err := ui.userOutputPort.OutputCreateResult(); err != nil {
@@ -56,7 +56,7 @@ func (ui *UserInteractor) SignupDraft(code string) error {
 		Sex:    0.0,
 		Gender: 0.0,
 	}
-	if err := ui.userRepository.Create(user); err != nil {
+	if user, err = ui.userRepository.Create(user); err != nil {
 		return err
 	}
 

--- a/src/usecase/interactor/user.go
+++ b/src/usecase/interactor/user.go
@@ -59,8 +59,8 @@ func (ui *UserInteractor) SignupDraft(code string) error {
 	if user, err = ui.userRepository.Create(user); err != nil {
 		return err
 	}
-
-	if err := ui.userOutputPort.OutputSignupWithAuth(); err != nil {
+	// urlのクエリパラメータにidを付与してそのidをユーザの更新時に受け取りどのユーザを更新するかを判別する
+	if err := ui.userOutputPort.OutputSignupWithAuth(user.Id); err != nil {
 		return err
 	}
 	return nil

--- a/src/usecase/interactor/user.go
+++ b/src/usecase/interactor/user.go
@@ -18,10 +18,7 @@ func NewUserInputPort(userRepository port.UserRepository, userOutputPort port.Us
 }
 
 func (ui *UserInteractor) CreateUser(user *model.User) error {
-	// 存在しない場合にerrが返ってくるため、nilであればすでに存在しているということ
-	if err := ui.userRepository.Exist(user); err == nil {
-		return err
-	}
+
 	if _, err := ui.userRepository.Create(user); err != nil {
 		return err
 	}
@@ -59,6 +56,14 @@ func (ui *UserInteractor) SignupDraft(code string) error {
 		Age:    0,
 		Sex:    0.0,
 		Gender: 0.0,
+	}
+	// 存在しない場合にerrが返ってくるため、nilであればすでに存在しているということ
+	if err := ui.userRepository.Exist(user); err == nil {
+		// すでに登録されている場合はログイン画面に遷移させる
+		if err := ui.userOutputPort.OutputAlreadySignedup(); err != nil {
+			return err
+		}
+		return err
 	}
 	if user, err = ui.userRepository.Create(user); err != nil {
 		return err

--- a/src/usecase/interactor/user.go
+++ b/src/usecase/interactor/user.go
@@ -41,3 +41,27 @@ func (ui *UserInteractor) GetAuthUrl() error {
 	url := ui.userRepository.GenerateAuthUrl()
 	return ui.userOutputPort.OutputAuthUrl(url)
 }
+
+func (ui *UserInteractor) SignupDraft(code string) error {
+	email, err := ui.userRepository.GetUserInfoWithAuthCode(code)
+	if err != nil {
+		return err
+	}
+
+	// 先にemailのみで登録する(仮登録)
+	user := &model.User{
+		Name:   "",
+		Email:  email,
+		Age:    0,
+		Sex:    0.0,
+		Gender: 0.0,
+	}
+	if err := ui.userRepository.Create(user); err != nil {
+		return err
+	}
+
+	if err := ui.userOutputPort.OutputSignupWithAuth(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/usecase/interactor/user.go
+++ b/src/usecase/interactor/user.go
@@ -18,6 +18,10 @@ func NewUserInputPort(userRepository port.UserRepository, userOutputPort port.Us
 }
 
 func (ui *UserInteractor) CreateUser(user *model.User) error {
+	// 存在しない場合にerrが返ってくるため、nilであればすでに存在しているということ
+	if err := ui.userRepository.Exist(user); err == nil {
+		return err
+	}
 	if _, err := ui.userRepository.Create(user); err != nil {
 		return err
 	}

--- a/src/usecase/interactor/user_test.go
+++ b/src/usecase/interactor/user_test.go
@@ -16,9 +16,9 @@ type MockUserOutputPort struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) Create(user *model.User) error {
+func (m *MockUserRepository) Create(user *model.User) (*model.User, error) {
 	args := m.Called()
-	return args.Error(0)
+	return args.Get(0).(*model.User), args.Error(1)
 }
 
 func (m *MockUserRepository) GenerateAuthUrl() string {
@@ -59,10 +59,12 @@ func (m *MockUserOutputPort) OutputSignupWithAuth() error {
 func TestCreateUser(t *testing.T) {
 	/* Arrange */
 	var expected error = nil
-	user := &model.User{Id: 1, Name: "natori", Email: "test@example.com", Age: 52, Sex: -0.2, Gender: 1.0}
+	user := &model.User{Name: "natori", Email: "test@example.com", Age: 52, Sex: -0.2, Gender: 1.0}
+	returnedUser := user
+	returnedUser.Id = 1
 
 	mockUserRepository := new(MockUserRepository)
-	mockUserRepository.On("Create").Return(nil)
+	mockUserRepository.On("Create").Return(returnedUser, nil)
 	mockUserOutputPort := new(MockUserOutputPort)
 	mockUserOutputPort.On("OutputCreateResult").Return(nil)
 
@@ -136,7 +138,7 @@ func TestSignupDraft(t *testing.T) {
 
 	mockUserRepository := new(MockUserRepository)
 	mockUserRepository.On("GetUserInfoWithAuthCode").Return(email, nil)
-	mockUserRepository.On("Create").Return(nil)
+	mockUserRepository.On("Create").Return(&model.User{}, nil)
 	mockUserOutputPort := new(MockUserOutputPort)
 	mockUserOutputPort.On("OutputSignupWithAuth").Return(nil)
 

--- a/src/usecase/interactor/user_test.go
+++ b/src/usecase/interactor/user_test.go
@@ -31,6 +31,11 @@ func (m *MockUserRepository) FindBy(user *model.UserCredentials) error {
 	return args.Error(0)
 }
 
+func (m *MockUserRepository) GetUserInfoWithAuthCode(string) (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+
 func (m *MockUserOutputPort) OutputCreateResult() error {
 	args := m.Called()
 	return args.Error(0)
@@ -42,6 +47,11 @@ func (m *MockUserOutputPort) OutputLoginResult() error {
 }
 
 func (m *MockUserOutputPort) OutputAuthUrl(url string) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockUserOutputPort) OutputSignupWithAuth() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -118,3 +128,29 @@ func TestGetAuthUrl(t *testing.T) {
 	mockUserOutputPort.AssertNumberOfCalls(t, "OutputAuthUrl", 1)
 }
 
+func TestSignupDraft(t *testing.T) {
+	/* Arrange */
+	code := ""
+	email := "sample@example.com"
+	var expected error = nil
+
+	mockUserRepository := new(MockUserRepository)
+	mockUserRepository.On("GetUserInfoWithAuthCode").Return(email, nil)
+	mockUserRepository.On("Create").Return(nil)
+	mockUserOutputPort := new(MockUserOutputPort)
+	mockUserOutputPort.On("OutputSignupWithAuth").Return(nil)
+
+	ui := &UserInteractor{
+		userRepository: mockUserRepository,
+		userOutputPort: mockUserOutputPort,
+	}
+
+	/* Act */
+	actual := ui.SignupDraft(code)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockUserRepository.AssertNumberOfCalls(t, "GetUserInfoWithAuthCode", 1)
+	mockUserRepository.AssertNumberOfCalls(t, "Create", 1)
+	mockUserOutputPort.AssertNumberOfCalls(t, "OutputSignupWithAuth", 1)
+}

--- a/src/usecase/interactor/user_test.go
+++ b/src/usecase/interactor/user_test.go
@@ -51,7 +51,7 @@ func (m *MockUserOutputPort) OutputAuthUrl(url string) error {
 	return args.Error(0)
 }
 
-func (m *MockUserOutputPort) OutputSignupWithAuth() error {
+func (m *MockUserOutputPort) OutputSignupWithAuth(id int) error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -12,7 +12,7 @@ type UserInputPort interface {
 }
 
 type UserRepository interface {
-	Create(*model.User) error
+	Create(*model.User) (*model.User, error)
 	FindBy(*model.UserCredentials) error
 	GenerateAuthUrl() string
 	GetUserInfoWithAuthCode(string) (string, error)
@@ -21,6 +21,6 @@ type UserRepository interface {
 type UserOutputPort interface {
 	OutputCreateResult() error
 	OutputLoginResult() error
-	OutputAuthUrl(url string) error
+	OutputAuthUrl(string) error
 	OutputSignupWithAuth() error
 }

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -22,5 +22,5 @@ type UserOutputPort interface {
 	OutputCreateResult() error
 	OutputLoginResult() error
 	OutputAuthUrl(string) error
-	OutputSignupWithAuth() error
+	OutputSignupWithAuth(int) error
 }

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -12,6 +12,7 @@ type UserInputPort interface {
 }
 
 type UserRepository interface {
+	Exist(*model.User) error
 	Create(*model.User) (*model.User, error)
 	FindBy(*model.UserCredentials) error
 	GenerateAuthUrl() string

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -8,16 +8,19 @@ type UserInputPort interface {
 	CreateUser(*model.User) error
 	LoginUser(*model.UserCredentials) error
 	GetAuthUrl() error
+	SignupDraft(string) error
 }
 
 type UserRepository interface {
 	Create(*model.User) error
 	FindBy(*model.UserCredentials) error
 	GenerateAuthUrl() string
+	GetUserInfoWithAuthCode(string) (string, error)
 }
 
 type UserOutputPort interface {
 	OutputCreateResult() error
 	OutputLoginResult() error
 	OutputAuthUrl(url string) error
+	OutputSignupWithAuth() error
 }

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -24,4 +24,5 @@ type UserOutputPort interface {
 	OutputLoginResult() error
 	OutputAuthUrl(string) error
 	OutputSignupWithAuth(int) error
+	OutputAlreadySignedup() error
 }


### PR DESCRIPTION
OAuthを用いた仮登録になります。
user-authブランチによって、認証用のURLを発行したので、それに対して認証を入れるgoogleアカウントを選択した際にそのアカウントのemailを用いてuserの登録を行います。
**※仮登録と言っても仮登録用のテーブルは用いず、emailだけでuserを作成します。**

登録後はuserのその他の情報(name,age等)を入力する画面へとリダイレクトします。
その際にurlにidを持たせて、更新時にクライアントからidとuserの情報を送信し、idを用いてどのuserを更新するかを決めます。

## 実行手順
- バックエンドを起動後に`curl -v http://localhost:8080/auth`で起動
- 表示されたlocationにアクセスしてgoogle認証を行う
- 認証後にページが遷移し、urlが`FRONT_URL/editUser?id=x`となる(xはUserのDBのid)
- UserのDBを確認するとemailのみで登録されたユーザが存在する

## 実行時の注意点
- GoogleCouldPlatformの「OAuth 2.0 クライアント ID」の「承認済みのリダイレクト URI」に`http://localhost:8080/auth/signup`を追加もしくは既存のものから変更してください。