### PR TITLE
[draft] favorite_storesテーブルにお気に入りのお店情報を保存

### DIFF
--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -22,6 +22,7 @@ type StoreRequestBody struct {
 type StoreI interface {
 	GetStores(c echo.Context) error
 	GetNearStores(c echo.Context) error
+	SaveFavoriteStore(c echo.Context) error
 }
 
 type StoreOutputFactory func(echo.Context) port.StoreOutputPort

--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -61,6 +61,10 @@ func (sc *StoreController) GetNearStores(c echo.Context) error {
 	return sc.newStoreInputPort(c).GetNearStores()
 }
 
+func (sc *StoreController) SaveFavoriteStore(c echo.Context) error {
+	return sc.newStoreInputPort(c).SaveFavoriteStore()
+}
+
 /* ここでpresenterにecho.Contextを渡している！起爆！！！（遅延） */
 /* これによって、presenterのinterface(outputport)にecho.Contextを書かなくて良くなる */
 func (sc *StoreController) newStoreInputPort(c echo.Context) port.StoreInputPort {

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bytes"
 	"clean-storemap-api/src/adapter/gateway"
 	api "clean-storemap-api/src/driver/api"
 	db "clean-storemap-api/src/driver/db"
@@ -81,7 +82,7 @@ func (m *MockStoreInputFactoryFuncObject) GetNearStores() error {
 	return args.Error(0)
 }
 
-func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore() error {
+func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(*model.Store) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -171,10 +172,23 @@ func TestGetNearStores(t *testing.T) {
 	mockStoreInputFactoryFuncObject.AssertNumberOfCalls(t, "GetNearStores", 1)
 }
 
-func TestSaveStore(t *testing.T) {
+func TestFavoriteSaveStore(t *testing.T) {
 	/* Arrange */
 	c, rec := newRouter()
 	expected := errors.New("")
+
+	reqBody := `{
+		"id": "Id001",
+		"name": "UEC cafe",
+		"regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+		"priceLevel": "PRICE_LEVEL_MODERATE",
+		"latitude": "35.713",
+		"longitude": "139.762"
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/favorite-store", bytes.NewBufferString(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c.SetRequest(req)
 
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("GetStores").Return([]*db.FavoriteStore{}, nil)

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -44,12 +44,22 @@ func (m *MockStoreDriverFactory) GetStores() ([]*db.FavoriteStore, error) {
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
+func (m *MockStoreDriverFactory) SaveStore(*db.FavoriteStore) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *MockGoogleMapDriverFactory) GetStores() ([]*api.Store, error) {
 	args := m.Called()
 	return args.Get(0).([]*api.Store), args.Error(1)
 }
 
 func (m *MockStoreOutputFactoryFuncObject) OutputAllStores([]*model.Store) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStoreOutputFactoryFuncObject) OutputSaveFavoriteStoreResult() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -66,6 +76,11 @@ func (m *MockStoreRepositoryFactoryFuncObject) GetAll() ([]*model.Store, error) 
 func (m *MockStoreRepositoryFactoryFuncObject) GetNearStores() ([]*model.Store, error) {
 	args := m.Called()
 	return args.Get(0).([]*model.Store), args.Error(1)
+}
+
+func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(*model.Store) error {
+	args := m.Called()
+	return args.Error(0)
 }
 
 func mockStoreRepositoryFactoryFunc(storeDriver gateway.StoreDriver, googleMapDriver gateway.GoogleMapDriver) port.StoreRepository {
@@ -116,6 +131,7 @@ func TestGetStores(t *testing.T) {
 	// Driverだけは実体が必要
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("GetStores").Return([]*db.FavoriteStore{}, nil)
+	mockStoreDriverFactory.On("SaveStore").Return(nil)
 
 	// InputPortのGetStoresのモックを作成
 	sc := &StoreController{
@@ -174,8 +190,8 @@ func TestGetNearStores(t *testing.T) {
 
 func TestFavoriteSaveStore(t *testing.T) {
 	/* Arrange */
+	var expected error = nil
 	c, rec := newRouter()
-	expected := errors.New("")
 
 	reqBody := `{
 		"id": "Id001",
@@ -192,6 +208,7 @@ func TestFavoriteSaveStore(t *testing.T) {
 
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("GetStores").Return([]*db.FavoriteStore{}, nil)
+	mockStoreDriverFactory.On("SaveStore").Return(nil)
 
 	sc := &StoreController{
 		storeDriverFactory:     mockStoreDriverFactory,
@@ -200,7 +217,7 @@ func TestFavoriteSaveStore(t *testing.T) {
 	}
 
 	mockStoreInputFactoryFuncObject := new(MockStoreInputFactoryFuncObject)
-	mockStoreInputFactoryFuncObject.On("SaveFavoriteStore").Return(expected)
+	mockStoreInputFactoryFuncObject.On("SaveFavoriteStore").Return(nil)
 	sc.storeInputFactory = func(repository port.StoreRepository, output port.StoreOutputPort) port.StoreInputPort {
 		return mockStoreInputFactoryFuncObject
 	}

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -17,6 +17,7 @@ type StoreGateway struct {
 
 type StoreDriver interface {
 	GetStores() ([]*db.FavoriteStore, error)
+	SaveStore(*db.FavoriteStore) error
 }
 
 type GoogleMapDriver interface {
@@ -70,4 +71,22 @@ func (sg *StoreGateway) GetNearStores() ([]*model.Store, error) {
 		})
 	}
 	return stores, nil
+}
+
+func (sg *StoreGateway) SaveFavoriteStore(store *model.Store) error {
+	dbStore := &db.FavoriteStore{
+		Id:                  store.Id,
+		Name:                store.Name,
+		RegularOpeningHours: store.RegularOpeningHours,
+		PriceLevel:          store.PriceLevel,
+		Latitude:            store.Location.Lat,
+		Longitude:           store.Location.Lng,
+	}
+
+	err := sg.storeDriver.SaveStore(dbStore)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -16,7 +16,7 @@ type StoreGateway struct {
 }
 
 type StoreDriver interface {
-	GetStores() ([]*db.Store, error)
+	GetStores() ([]*db.FavoriteStore, error)
 }
 
 type GoogleMapDriver interface {

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -59,6 +59,11 @@ func (m *MockStoreRepository) GetStores() ([]*db.FavoriteStore, error) {
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
+func (m *MockStoreRepository) SaveStore(*db.FavoriteStore) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 type MockGoogleMapRepository struct {
 	mock.Mock
 }
@@ -137,4 +142,26 @@ func TestGetNearStores(t *testing.T) {
 	/* Assert */
 	assert.Equal(t, expected, actual)
 	mockGoogleMapRepository.AssertNumberOfCalls(t, "GetStores", 1)
+}
+
+func TestSaveFavoriteStore(t *testing.T) {
+	/* Arrange */
+	var expected error = nil
+	mockStoreRepository := new(MockStoreRepository)
+	mockStoreRepository.On("SaveStore").Return(nil)
+	sg := &StoreGateway{storeDriver: mockStoreRepository}
+	store := &model.Store{
+		Id:                  "Id001",
+		Name:                "UEC cafe",
+		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+		PriceLevel:          "PRICE_LEVEL_MODERATE",
+		Location:            model.Location{Lat: "35.713", Lng: "139.762"},
+	}
+
+	/* Act */
+	actual := sg.SaveFavoriteStore(store)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockStoreRepository.AssertNumberOfCalls(t, "SaveStore", 1)
 }

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func makeDummyDbStores() ([]*db.Store, error) {
-	dummyStores := make([]*db.Store, 0)
-	dummyStores = append(dummyStores, &db.Store{
+func makeDummyDbStores() ([]*db.FavoriteStore, error) {
+	dummyStores := make([]*db.FavoriteStore, 0)
+	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "Id001",
 		Name:                "UEC cafe",
 		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
@@ -20,7 +20,7 @@ func makeDummyDbStores() ([]*db.Store, error) {
 		Latitude:            "35.713",
 		Longitude:           "139.762",
 	})
-	dummyStores = append(dummyStores, &db.Store{
+	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "Id002",
 		Name:                "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
@@ -54,9 +54,9 @@ type MockStoreRepository struct {
 	mock.Mock
 }
 
-func (m *MockStoreRepository) GetStores() ([]*db.Store, error) {
+func (m *MockStoreRepository) GetStores() ([]*db.FavoriteStore, error) {
 	args := m.Called()
-	return args.Get(0).([]*db.Store), args.Error(1)
+	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
 type MockGoogleMapRepository struct {

--- a/src/adapter/presenter/store.go
+++ b/src/adapter/presenter/store.go
@@ -50,3 +50,7 @@ func (sp *StorePresenter) OutputAllStores(stores []*model.Store) error {
 	output_json := &StoreOutputJson{Stores: json_stores}
 	return sp.c.JSON(http.StatusOK, output_json)
 }
+
+func (sp *StorePresenter) OutputSaveFavoriteStoreResult() error {
+	return sp.c.JSON(http.StatusOK, map[string]interface{}{})
+}

--- a/src/adapter/presenter/store_test.go
+++ b/src/adapter/presenter/store_test.go
@@ -46,3 +46,19 @@ func TestOutputAllStores(t *testing.T) {
 		assert.Equal(t, expected, rec.Body.String())
 	}
 }
+
+func TestOutputSaveFavoriteStoreResult(t *testing.T) {
+	/* Arrange */
+	expected := "{}\n"
+	c, rec := newRouter()
+	sp := &StorePresenter{c: c}
+
+	/* Act */
+	actual := sp.OutputSaveFavoriteStoreResult()
+
+	/* Assert */
+	// sp.OutputSaveFavoriteStoreResult()がJSONを返すこ
+	if assert.NoError(t, actual) {
+		assert.Equal(t, expected, rec.Body.String())
+	}
+}

--- a/src/driver/db/initdb.go
+++ b/src/driver/db/initdb.go
@@ -9,6 +9,7 @@ import (
 )
 
 var DB *gorm.DB
+
 func InitDB() {
 	dsn := os.Getenv("TESTDB_CONNECTION")
 
@@ -20,6 +21,6 @@ func InitDB() {
 	}
 
 	// ここで使用するすべての構造体をMigrate
-	DB.AutoMigrate(&Store{})
+	DB.AutoMigrate(&FavoriteStore{})
 	DB.AutoMigrate(&User{})
 }

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -11,7 +11,7 @@ func NewStoreDriver() *DbStoreDriver {
 }
 
 /* interfaceと型は同義。仮にgatewayがDBの型を知ったとしても、どんなDBから来たかわかるわけではないのでおk */
-type Store struct {
+type FavoriteStore struct {
 	Id                  string `gorm:"primaryKey"`
 	Name                string
 	RegularOpeningHours string
@@ -22,8 +22,8 @@ type Store struct {
 	UpdatedAt           time.Time
 }
 
-func (dbs *DbStoreDriver) GetStores() ([]*Store, error) {
-	var stores []*Store
+func (dbs *DbStoreDriver) GetStores() ([]*FavoriteStore, error) {
+	var stores []*FavoriteStore
 	err := DB.Find(&stores).Error
 	if err != nil {
 		return nil, err

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -30,3 +30,11 @@ func (dbs *DbStoreDriver) GetStores() ([]*FavoriteStore, error) {
 	}
 	return stores, nil
 }
+
+func (dbs *DbStoreDriver) SaveStore(store *FavoriteStore) error {
+	err := DB.Create(&store).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -13,11 +13,11 @@ func NewStoreDriver() *DbStoreDriver {
 /* interfaceと型は同義。仮にgatewayがDBの型を知ったとしても、どんなDBから来たかわかるわけではないのでおk */
 type FavoriteStore struct {
 	Id                  string `gorm:"primaryKey"`
-	Name                string
+	Name                string `gorm:"not null"`
 	RegularOpeningHours string
 	PriceLevel          string
-	Latitude            string
-	Longitude           string
+	Latitude            string `gorm:"not null"`
+	Longitude           string `gorm:"not null"`
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -42,6 +42,7 @@ func NewRouter(echo *echo.Echo, storeController controller.StoreI, userControlle
 func (router *Router) Serve(ctx context.Context) {
 	router.echo.GET("/", router.storeController.GetStores)
 	router.echo.GET("/stores/opening-hours", router.storeController.GetNearStores)
+	router.echo.POST("/stores/favorite", router.storeController.SaveFavoriteStore)
 	router.echo.POST("/user", router.userController.CreateUser)
 	router.echo.POST("/login", router.userController.LoginUser)
 	router.echo.GET("/auth", router.userController.GetAuthUrl) // Google認証用のURLを取得し返す(ユーザの登録はsignupで行う)

--- a/src/entity/store.go
+++ b/src/entity/store.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"errors"
+	"strconv"
+)
+
 type Location struct {
 	Lat string
 	Lng string
@@ -11,4 +16,44 @@ type Store struct {
 	RegularOpeningHours string
 	PriceLevel          string
 	Location            Location
+}
+
+func (l Location) Validate() error {
+	// 緯度が-90から90の間にあるかチェック
+	lat, err := strconv.ParseFloat(l.Lat, 64)
+	if err != nil {
+		return errors.New("latitude is invalid")
+	}
+	if lat < -90 || lat > 90 {
+		return errors.New("latitude must be between -90 and 90, got " + l.Lat)
+	}
+
+	// 経度が-180から180の間にあるかチェック
+	lng, err := strconv.ParseFloat(l.Lng, 64)
+	if err != nil {
+		return errors.New("longitude is invalid")
+	}
+	if lng < -180 || lng > 180 {
+		return errors.New("longitude must be between -180 and 180, got " + l.Lng)
+	}
+
+	return nil
+}
+
+func NewStore(id string, name string, regularOpeningHours string, priceLevel string, lat string, lng string) (*Store, error) {
+	location := Location{Lat: lat, Lng: lng}
+
+	if err := location.Validate(); err != nil {
+		return nil, err
+	}
+
+	store := &Store{
+		Id:                  id,
+		Name:                name,
+		RegularOpeningHours: regularOpeningHours,
+		PriceLevel:          priceLevel,
+		Location:            location,
+	}
+
+	return store, nil
 }

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -34,5 +34,11 @@ func (si *StoreInteractor) GetNearStores() error {
 }
 
 func (si *StoreInteractor) SaveFavoriteStore(store *model.Store) error {
+	if err := si.storeRepository.SaveFavoriteStore(store); err != nil {
+		return err
+	}
+	if err := si.storeOutputPort.OutputSaveFavoriteStoreResult(); err != nil {
+		return err
+	}
 	return nil
 }

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -1,6 +1,7 @@
 package interactor
 
 import (
+	model "clean-storemap-api/src/entity"
 	port "clean-storemap-api/src/usecase/port"
 )
 
@@ -30,4 +31,8 @@ func (si *StoreInteractor) GetNearStores() error {
 		return err
 	}
 	return si.storeOutputPort.OutputAllStores(places)
+}
+
+func (si *StoreInteractor) SaveFavoriteStore(store *model.Store) error {
+	return nil
 }

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -26,13 +26,18 @@ func (m *MockStoreRepository) GetNearStores() ([]*model.Store, error) {
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepository) SaveFavoriteStore() error {
+func (m *MockStoreRepository) SaveFavoriteStore(*model.Store) error {
 	args := m.Called()
 	return args.Error(0)
 }
 
 func (m *MockStoreOutputPort) OutputAllStores(stores []*model.Store) error {
 	args := m.Called(stores)
+	return args.Error(0)
+}
+
+func (m *MockStoreOutputPort) OutputSaveFavoriteStoreResult() error {
+	args := m.Called()
 	return args.Error(0)
 }
 

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -26,8 +26,8 @@ func (m *MockStoreRepository) GetNearStores() ([]*model.Store, error) {
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepository) SaveFavoriteStore(*model.Store) error {
-	args := m.Called()
+func (m *MockStoreRepository) SaveFavoriteStore(store *model.Store) error {
+	args := m.Called(store)
 	return args.Error(0)
 }
 
@@ -111,7 +111,7 @@ func TestGetNearStores(t *testing.T) {
 
 func TestSaveFavoriteStore(t *testing.T) {
 	/* Arrange */
-	expected := errors.New("")
+	var expected error = nil
 	store := &model.Store{
 		Id:                  "Id001",
 		Name:                "UEC cafe",
@@ -121,8 +121,9 @@ func TestSaveFavoriteStore(t *testing.T) {
 	}
 
 	mockStoreRepository := new(MockStoreRepository)
-	mockStoreRepository.On("SaveFavoriteStore").Return(expected)
+	mockStoreRepository.On("SaveFavoriteStore", store).Return(nil)
 	mockStoreOutputPort := new(MockStoreOutputPort)
+	mockStoreOutputPort.On("OutputSaveFavoriteStoreResult").Return(nil)
 
 	si := &StoreInteractor{storeRepository: mockStoreRepository, storeOutputPort: mockStoreOutputPort}
 
@@ -132,4 +133,7 @@ func TestSaveFavoriteStore(t *testing.T) {
 	/* Assert */
 	assert.Equal(t, expected, actual)
 	mockStoreRepository.AssertNumberOfCalls(t, "SaveFavoriteStore", 1)
+	mockStoreOutputPort.AssertNumberOfCalls(t, "OutputSaveFavoriteStoreResult", 1)
+	// RepositoryのSaveFavoriteStoreがstoreを引数として呼ばれること
+	mockStoreRepository.AssertCalled(t, "SaveFavoriteStore", store)
 }

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -26,6 +26,11 @@ func (m *MockStoreRepository) GetNearStores() ([]*model.Store, error) {
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
+func (m *MockStoreRepository) SaveFavoriteStore() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *MockStoreOutputPort) OutputAllStores(stores []*model.Store) error {
 	args := m.Called(stores)
 	return args.Error(0)
@@ -97,4 +102,29 @@ func TestGetNearStores(t *testing.T) {
 	mockStoreRepository.AssertNumberOfCalls(t, "GetNearStores", 1)
 	mockStoreOutputPort.AssertNumberOfCalls(t, "OutputAllStores", 1)
 	mockStoreOutputPort.AssertCalled(t, "OutputAllStores", stores)
+}
+
+func TestSaveFavoriteStore(t *testing.T) {
+	/* Arrange */
+	expected := errors.New("")
+	store := &model.Store{
+		Id:                  "Id001",
+		Name:                "UEC cafe",
+		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+		PriceLevel:          "PRICE_LEVEL_MODERATE",
+		Location:            model.Location{Lat: "35.713", Lng: "139.762"},
+	}
+
+	mockStoreRepository := new(MockStoreRepository)
+	mockStoreRepository.On("SaveFavoriteStore").Return(expected)
+	mockStoreOutputPort := new(MockStoreOutputPort)
+
+	si := &StoreInteractor{storeRepository: mockStoreRepository, storeOutputPort: mockStoreOutputPort}
+
+	/* Act */
+	actual := si.SaveFavoriteStore(store)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockStoreRepository.AssertNumberOfCalls(t, "SaveFavoriteStore", 1)
 }

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -7,7 +7,7 @@ import (
 type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
-	SaveFavoriteStore() error
+	SaveFavoriteStore(*model.Store) error
 }
 
 type StoreRepository interface {

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -13,8 +13,10 @@ type StoreInputPort interface {
 type StoreRepository interface {
 	GetAll() ([]*model.Store, error)
 	GetNearStores() ([]*model.Store, error)
+	SaveFavoriteStore(*model.Store) error
 }
 
 type StoreOutputPort interface {
 	OutputAllStores([]*model.Store) error
+	OutputSaveFavoriteStoreResult() error
 }

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -7,6 +7,7 @@ import (
 type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
+	SaveFavoriteStore() error
 }
 
 type StoreRepository interface {


### PR DESCRIPTION
## 本PRでやったこと
- `POST /stores/favorite`の作成
- 各レイヤーのテスト実装

## 実行例
- 画面上部はpostmanで叩く様子、下部はdbに保存された様子
<img width="1367" alt="Screenshot 2024-11-21 at 12 35 22" src="https://github.com/user-attachments/assets/f79e1ff0-d49b-4633-b9a1-6f7ba71e5564">

## Todo
- storeIdとは別にユニークなidとuserIdを追加すべき
- 対象userに対してすでにstoreが登録されていたらエラー

## Next
- お気に入り件数ランキングページのためのGETメソッド実装
- 余裕があればお気に入りを取り消したい
