### PR TITLE
Userのupdate機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ curl -H "Content-Type: application/json" -X POST -d "@example/create_user_api_
 ### update user
 
 ```
-$ curl -H "Content-Type: application/json" -X PATCH -d "@example/update_user_api_example.json" http://localhost:8080/user
+$ curl -H "Content-Type: application/json" -X PUT -d "@example/update_user_api_example.json" http://localhost:8080/user/1
 ```
 
 ### Login user

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ $ curl http://localhost:8080
 $ curl -H "Content-Type: application/json" -X POST -d "@example/create_user_api_example.json" http://localhost:8080/user
 ```
 
+### update user
+
+```
+$ curl -H "Content-Type: application/json" -X PATCH -d "@example/update_user_api_example.json" http://localhost:8080/user
+```
+
 ### Login user
 - dbにlogin_user_api_example.jsonに記載されているemailがある => {}
 - dbにlogin_user_api_example.jsonに記載されているemailがない => エラーメッセージとなる

--- a/example/update_user_api_example.json
+++ b/example/update_user_api_example.json
@@ -1,0 +1,8 @@
+{
+    "id": 1,
+    "name": "updatedJohnathan",
+    "email": "updatedjohnathan@example.com",
+    "age": 58,
+    "sex": 1.0,
+    "gender": -1.0
+}

--- a/example/update_user_api_example.json
+++ b/example/update_user_api_example.json
@@ -1,5 +1,4 @@
 {
-    "id": 1,
     "name": "updatedJohnathan",
     "age": 58,
     "sex": 1.0,

--- a/example/update_user_api_example.json
+++ b/example/update_user_api_example.json
@@ -1,7 +1,6 @@
 {
     "id": 1,
     "name": "updatedJohnathan",
-    "email": "updatedjohnathan@example.com",
     "age": 58,
     "sex": 1.0,
     "gender": -1.0

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -93,6 +93,11 @@ func (m *MockUserOutputFactoryFuncObject) OutputAlreadySignedup() error {
 	return args.Error(0)
 }
 
+func (m *MockUserOutputFactoryFuncObject) OutputHasEmailInRequestBody() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func mockUserOutputFactoryFunc(c echo.Context) port.UserOutputPort {
 	return &MockUserOutputFactoryFuncObject{}
 }

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -44,7 +44,7 @@ func (m *MockUserDriverFactory) UpdateUser(*db.User, map[string]interface{}) err
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockUserDriverFactory) GetUser(int) (*db.User, error) {
+func (m *MockUserDriverFactory) FindById(int) (*db.User, error) {
 	args := m.Called()
 	return args.Get(0).(*db.User), args.Error(1)
 }
@@ -107,7 +107,7 @@ func (m *MockUserRepositoryFactoryFuncObject) Exist(*model.User) error {
 	return args.Error(0)
 }
 
-func (m *MockUserRepositoryFactoryFuncObject) Update(*model.User, map[string]interface{}) error {
+func (m *MockUserRepositoryFactoryFuncObject) Update(*model.User, model.ChangeForUser) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -140,7 +140,7 @@ func (m *MockUserInputFactoryFuncObject) CreateUser(*model.User) error {
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockUserInputFactoryFuncObject) UpdateUser(map[string]interface{}) error {
+func (m *MockUserInputFactoryFuncObject) UpdateUser(int, model.ChangeForUser) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -204,11 +204,13 @@ func TestUpdateUser(t *testing.T) {
 	/* Arrange */
 	c, rec := newRouter()
 	var expected error = nil
-	// 更新するデータ
-	reqBody := `{"id":1,"name":"noiman","age":10,"sex":0.4, "gender":0}`
-	req := httptest.NewRequest(http.MethodPatch, "/user", bytes.NewBufferString(reqBody))
+	reqBody := `{"name":"test","age":10,"sex":0.4, "gender":0}`
+	req := httptest.NewRequest(http.MethodPut, "/user/1", bytes.NewBufferString(reqBody))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c.SetRequest(req)
+	// パスパラメータを設定
+	c.SetParamNames("id")
+	c.SetParamValues("1")
 
 	// Driver用
 	mockUserDriverFactory := new(MockUserDriverFactory)

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -40,9 +40,17 @@ func (m *MockUserDriverFactory) CreateUser(*db.User) (*db.User, error) {
 	return args.Get(0).(*db.User), args.Error(1)
 }
 
-func (m *MockUserDriverFactory) FindByEmail(string) error {
+func (m *MockUserDriverFactory) UpdateUser(*db.User, map[string]interface{}) error {
 	args := m.Called()
 	return args.Error(0)
+}
+func (m *MockUserDriverFactory) GetUser(int) (*db.User, error) {
+	args := m.Called()
+	return args.Get(0).(*db.User), args.Error(1)
+}
+func (m *MockUserDriverFactory) FindByEmail(string) (*db.User, error) {
+	args := m.Called()
+	return args.Get(0).(*db.User), args.Error(1)
 }
 
 func (m *MockGoogleOAuthDriverFactory) GenerateUrl() string {
@@ -56,6 +64,11 @@ func (m *MockGoogleOAuthDriverFactory) GetEmail(string) (string, error) {
 }
 
 func (m *MockUserOutputFactoryFuncObject) OutputCreateResult() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockUserOutputFactoryFuncObject) OutputUpdateResult() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -88,18 +101,30 @@ func (m *MockUserRepositoryFactoryFuncObject) Create(*model.User) (*model.User, 
 	args := m.Called()
 	return args.Get(0).(*model.User), args.Error(1)
 }
+
 func (m *MockUserRepositoryFactoryFuncObject) Exist(*model.User) error {
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockUserRepositoryFactoryFuncObject) GenerateAuthUrl() string {
+
+func (m *MockUserRepositoryFactoryFuncObject) Update(*model.User, map[string]interface{}) error {
 	args := m.Called()
-	return args.Get(0).(string)
+	return args.Error(0)
+}
+
+func (m *MockUserRepositoryFactoryFuncObject) Get(int) (*model.User, error) {
+	args := m.Called()
+	return args.Get(0).(*model.User), args.Error(1)
 }
 
 func (m *MockUserRepositoryFactoryFuncObject) FindBy(*model.UserCredentials) error {
 	args := m.Called()
 	return args.Error(0)
+}
+
+func (m *MockUserRepositoryFactoryFuncObject) GenerateAuthUrl() string {
+	args := m.Called()
+	return args.Get(0).(string)
 }
 
 func (m *MockUserRepositoryFactoryFuncObject) GetUserInfoWithAuthCode(string) (string, error) {
@@ -112,6 +137,10 @@ func mockUserRepositoryFactoryFunc(userDriver gateway.UserDriver, googleOAuthDri
 }
 
 func (m *MockUserInputFactoryFuncObject) CreateUser(*model.User) error {
+	args := m.Called()
+	return args.Error(0)
+}
+func (m *MockUserInputFactoryFuncObject) UpdateUser(map[string]interface{}) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -171,6 +200,40 @@ func TestCreateUser(t *testing.T) {
 	mockUserInputFactoryFuncObject.AssertNumberOfCalls(t, "CreateUser", 1)
 }
 
+func TestUpdateUser(t *testing.T) {
+	/* Arrange */
+	c, rec := newRouter()
+	var expected error = nil
+	// 更新するデータ
+	reqBody := `{"id":1,"name":"noiman","age":10,"sex":0.4, "gender":0}`
+	req := httptest.NewRequest(http.MethodPatch, "/user", bytes.NewBufferString(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c.SetRequest(req)
+
+	// Driver用
+	mockUserDriverFactory := new(MockUserDriverFactory)
+
+	uc := &UserController{
+		userDriverFactory:     mockUserDriverFactory,
+		userOutputFactory:     mockUserOutputFactoryFunc,
+		userRepositoryFactory: mockUserRepositoryFactoryFunc,
+	}
+
+	mockUserInputFactoryFuncObject := new(MockUserInputFactoryFuncObject)
+	mockUserInputFactoryFuncObject.On("UpdateUser").Return(nil)
+	uc.userInputFactory = func(repository port.UserRepository, output port.UserOutputPort) port.UserInputPort {
+		return mockUserInputFactoryFuncObject
+	}
+
+	/* Act */
+	actual := uc.UpdateUser(c)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	mockUserInputFactoryFuncObject.AssertNumberOfCalls(t, "UpdateUser", 1)
+}
+
 func TestLoginUser(t *testing.T) {
 	/* Arrange */
 	c, rec := newRouter()
@@ -183,7 +246,7 @@ func TestLoginUser(t *testing.T) {
 
 	// Driverだけは実体が必要
 	mockUserDriverFactory := new(MockUserDriverFactory)
-	mockUserDriverFactory.On("FindByEmail").Return(true)
+	mockUserDriverFactory.On("FindByEmail").Return(nil, nil)
 
 	// InputPortのLoginUserのモックを作成
 	uc := &UserController{

--- a/src/adapter/gateway/user.go
+++ b/src/adapter/gateway/user.go
@@ -13,7 +13,9 @@ type UserGateway struct {
 
 type UserDriver interface {
 	CreateUser(*db.User) (*db.User, error)
-	FindByEmail(string) error
+	UpdateUser(*db.User, map[string]interface{}) error
+	GetUser(int) (*db.User, error)
+	FindByEmail(string) (*db.User, error)
 }
 
 type GoogleOAuthDriver interface {
@@ -46,18 +48,51 @@ func (ug *UserGateway) Create(user *model.User) (*model.User, error) {
 }
 
 func (ug *UserGateway) Exist(user *model.User) error {
-	if err := ug.userDriver.FindByEmail(user.Email); err != nil {
+	if _, err := ug.userDriver.FindByEmail(user.Email); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (ug *UserGateway) FindBy(user *model.UserCredentials) error {
-	if err := ug.userDriver.FindByEmail(user.Email); err != nil {
+func (ug *UserGateway) Update(user *model.User, updatedUserData map[string]interface{}) error {
+	// updateされるUserをdb.Userに変換
+	dbUser := &db.User{
+		Id:     user.Id,
+		Name:   user.Name,
+		Email:  user.Email,
+		Age:    user.Age,
+		Sex:    user.Sex,
+		Gender: user.Gender,
+	}
+	if err := ug.userDriver.UpdateUser(dbUser, updatedUserData); err != nil {
 		return err
 	}
 	return nil
 }
+
+func (ug *UserGateway) Get(id int) (*model.User, error) {
+	dbUser, err := ug.userDriver.GetUser(id)
+	if err != nil {
+		return nil, err
+	}
+	user := &model.User{
+		Id:     dbUser.Id,
+		Name:   dbUser.Name,
+		Email:  dbUser.Email,
+		Age:    dbUser.Age,
+		Sex:    dbUser.Sex,
+		Gender: dbUser.Gender,
+	}
+	return user, nil
+}
+
+func (ug *UserGateway) FindBy(user *model.UserCredentials) error {
+	if _, err := ug.userDriver.FindByEmail(user.Email); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (ug *UserGateway) GenerateAuthUrl() string {
 	return ug.googleOAuthDriver.GenerateUrl()
 }

--- a/src/adapter/gateway/user.go
+++ b/src/adapter/gateway/user.go
@@ -14,7 +14,7 @@ type UserGateway struct {
 type UserDriver interface {
 	CreateUser(*db.User) (*db.User, error)
 	UpdateUser(*db.User, map[string]interface{}) error
-	GetUser(int) (*db.User, error)
+	FindById(int) (*db.User, error)
 	FindByEmail(string) (*db.User, error)
 }
 
@@ -54,7 +54,7 @@ func (ug *UserGateway) Exist(user *model.User) error {
 	return nil
 }
 
-func (ug *UserGateway) Update(user *model.User, updatedUserData map[string]interface{}) error {
+func (ug *UserGateway) Update(user *model.User, updateData model.ChangeForUser) error {
 	// updateされるUserをdb.Userに変換
 	dbUser := &db.User{
 		Id:     user.Id,
@@ -64,14 +64,14 @@ func (ug *UserGateway) Update(user *model.User, updatedUserData map[string]inter
 		Sex:    user.Sex,
 		Gender: user.Gender,
 	}
-	if err := ug.userDriver.UpdateUser(dbUser, updatedUserData); err != nil {
+	if err := ug.userDriver.UpdateUser(dbUser, updateData); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (ug *UserGateway) Get(id int) (*model.User, error) {
-	dbUser, err := ug.userDriver.GetUser(id)
+	dbUser, err := ug.userDriver.FindById(id)
 	if err != nil {
 		return nil, err
 	}

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -23,7 +23,7 @@ func (m *MockUserRepository) UpdateUser(*db.User, map[string]interface{}) error 
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) GetUser(int) (*db.User, error) {
+func (m *MockUserRepository) FindById(int) (*db.User, error) {
 	args := m.Called()
 	return args.Get(0).(*db.User), args.Error(1)
 }
@@ -114,27 +114,23 @@ func TestUpdate(t *testing.T) {
 		Gender: -0.1,
 	}
 	// 更新後のデータ
-	updatedUserData := map[string]interface{}{"name": "sample2", "sex": 1.0, "gender": -1.0}
+	updatedUserData := model.ChangeForUser{"name": "sample2", "sex": 1.0, "gender": -1.0}
 
 	mockUserRepository := new(MockUserRepository)
 	mockUserRepository.On("UpdateUser").Return(nil)
 	ug := &UserGateway{userDriver: mockUserRepository}
-	// ug := &UserGateway{userDriver: &db.DbUserDriver{}}
 
 	/* Act */
 	actual := ug.Update(user, updatedUserData)
 
 	/* Assert */
-	// 返り値が正しいこと
 	assert.Equal(t, expected, actual)
-	// userDriver.CreateUser()が1回呼ばれること
 	mockUserRepository.AssertNumberOfCalls(t, "UpdateUser", 1)
 }
 
 func TestGet(t *testing.T) {
 	/* Arrange */
 	id := 1
-	var expectedError error = nil
 	dbUser := &db.User{
 		Id:     id,
 		Name:   "sample",
@@ -144,6 +140,7 @@ func TestGet(t *testing.T) {
 		Gender: -0.5,
 	}
 
+	var expectedError error = nil
 	expectedUser := &model.User{
 		Id:     dbUser.Id,
 		Name:   dbUser.Name,
@@ -154,7 +151,7 @@ func TestGet(t *testing.T) {
 	}
 
 	mockUserRepository := new(MockUserRepository)
-	mockUserRepository.On("GetUser").Return(dbUser, nil)
+	mockUserRepository.On("FindById").Return(dbUser, nil)
 	ug := &UserGateway{userDriver: mockUserRepository}
 
 	/* Act */
@@ -165,7 +162,7 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, expectedUser, actual)
 	assert.Equal(t, expectedError, actualErr)
 	// userDriver.CreateUser()が1回呼ばれること
-	mockUserRepository.AssertNumberOfCalls(t, "GetUser", 1)
+	mockUserRepository.AssertNumberOfCalls(t, "FindById", 1)
 }
 
 func TestFindBy(t *testing.T) {

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -18,9 +18,19 @@ func (m *MockUserRepository) CreateUser(*db.User) (*db.User, error) {
 	return args.Get(0).(*db.User), args.Error(1)
 }
 
-func (m *MockUserRepository) FindByEmail(string) error {
+func (m *MockUserRepository) UpdateUser(*db.User, map[string]interface{}) error {
 	args := m.Called()
 	return args.Error(0)
+}
+
+func (m *MockUserRepository) GetUser(int) (*db.User, error) {
+	args := m.Called()
+	return args.Get(0).(*db.User), args.Error(1)
+}
+
+func (m *MockUserRepository) FindByEmail(string) (*db.User, error) {
+	args := m.Called()
+	return args.Get(0).(*db.User), args.Error(1)
 }
 func (m *MockUserRepository) GenerateUrl() string {
 	args := m.Called()
@@ -75,9 +85,10 @@ func TestExist(t *testing.T) {
 		Gender: -0.5,
 	}
 	var expected error = nil
+	foundUser := &db.User{}
 
 	mockUserRepository := new(MockUserRepository)
-	mockUserRepository.On("FindByEmail").Return(nil)
+	mockUserRepository.On("FindByEmail").Return(foundUser, nil)
 	ug := &UserGateway{userDriver: mockUserRepository}
 
 	/* Act */
@@ -88,17 +99,84 @@ func TestExist(t *testing.T) {
 	assert.Equal(t, expected, actual)
 	// userDriver.CreateUser()が1回呼ばれること
 	mockUserRepository.AssertNumberOfCalls(t, "FindByEmail", 1)
+	// mockUserRepository.AssertNumberOfCalls(t, "UpdateUser", 1)
+}
+func TestUpdate(t *testing.T) {
+	/* Arrange */
+	var expected error = nil
+	// 更新されるUser
+	user := &model.User{
+		Id:     1,
+		Name:   "sample",
+		Email:  "sample@example.com",
+		Age:    10,
+		Sex:    0.1,
+		Gender: -0.1,
+	}
+	// 更新後のデータ
+	updatedUserData := map[string]interface{}{"name": "sample2", "sex": 1.0, "gender": -1.0}
+
+	mockUserRepository := new(MockUserRepository)
+	mockUserRepository.On("UpdateUser").Return(nil)
+	ug := &UserGateway{userDriver: mockUserRepository}
+	// ug := &UserGateway{userDriver: &db.DbUserDriver{}}
+
+	/* Act */
+	actual := ug.Update(user, updatedUserData)
+
+	/* Assert */
+	// 返り値が正しいこと
+	assert.Equal(t, expected, actual)
+	// userDriver.CreateUser()が1回呼ばれること
+	mockUserRepository.AssertNumberOfCalls(t, "UpdateUser", 1)
+}
+
+func TestGet(t *testing.T) {
+	/* Arrange */
+	id := 1
+	var expectedError error = nil
+	dbUser := &db.User{
+		Id:     id,
+		Name:   "sample",
+		Email:  "sample@example.com",
+		Age:    20,
+		Sex:    1.0,
+		Gender: -0.5,
+	}
+
+	expectedUser := &model.User{
+		Id:     dbUser.Id,
+		Name:   dbUser.Name,
+		Email:  dbUser.Email,
+		Age:    dbUser.Age,
+		Sex:    dbUser.Sex,
+		Gender: dbUser.Gender,
+	}
+
+	mockUserRepository := new(MockUserRepository)
+	mockUserRepository.On("GetUser").Return(dbUser, nil)
+	ug := &UserGateway{userDriver: mockUserRepository}
+
+	/* Act */
+	actual, actualErr := ug.Get(id)
+
+	/* Assert */
+	// 返り値が正しいこと
+	assert.Equal(t, expectedUser, actual)
+	assert.Equal(t, expectedError, actualErr)
+	// userDriver.CreateUser()が1回呼ばれること
+	mockUserRepository.AssertNumberOfCalls(t, "GetUser", 1)
 }
 
 func TestFindBy(t *testing.T) {
 	/* Arrange */
 	var expected error = nil
-	mockUserRepository := new(MockUserRepository)
-	mockUserRepository.On("FindByEmail").Return(nil)
-	ug := &UserGateway{userDriver: mockUserRepository}
 	user := &model.UserCredentials{
 		Email: "noiman@groovex.co.jp",
 	}
+	mockUserRepository := new(MockUserRepository)
+	mockUserRepository.On("FindByEmail").Return(&db.User{}, nil)
+	ug := &UserGateway{userDriver: mockUserRepository}
 
 	/* Act */
 	actual := ug.FindBy(user)

--- a/src/adapter/presenter/user.go
+++ b/src/adapter/presenter/user.go
@@ -42,3 +42,8 @@ func (up *UserPresenter) OutputAlreadySignedup() error {
 	url := os.Getenv("FRONT_URL") // すでに登録済みの場合はトップページにリダイレクト
 	return up.c.Redirect(http.StatusFound, url)
 }
+
+func (up *UserPresenter) OutputHasEmailInRequestBody() error {
+	errMsg := "Email is included in Request Body"
+	return up.c.JSON(http.StatusBadRequest, map[string]interface{}{"error": errMsg})
+}

--- a/src/adapter/presenter/user.go
+++ b/src/adapter/presenter/user.go
@@ -21,6 +21,10 @@ func (up *UserPresenter) OutputCreateResult() error {
 	return up.c.JSON(http.StatusOK, map[string]interface{}{})
 }
 
+func (up *UserPresenter) OutputUpdateResult() error {
+	return up.c.JSON(http.StatusOK, map[string]interface{}{})
+}
+
 func (up *UserPresenter) OutputLoginResult() error {
 	return up.c.JSON(http.StatusOK, map[string]interface{}{})
 }

--- a/src/adapter/presenter/user_test.go
+++ b/src/adapter/presenter/user_test.go
@@ -95,3 +95,35 @@ func TestOutputSignupWithAuth(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	}
 }
+
+func TestOutputAlreadySignedup(t *testing.T) {
+	/* Arrange */
+	var expected error = nil
+	c, rec := newRouter()
+	up := &UserPresenter{c: c}
+
+	/* Act */
+	actual := up.OutputAlreadySignedup()
+
+	/* Assert */
+	if assert.NoError(t, actual) {
+		assert.Equal(t, http.StatusFound, rec.Code)
+		assert.Equal(t, expected, actual)
+	}
+}
+
+func TestOutputHasEmailInRequestBody(t *testing.T) {
+	/* Arrange */
+	expected := "{\"error\":\"Email is included in Request Body\"}\n"
+	c, rec := newRouter()
+	up := &UserPresenter{c: c}
+
+	/* Act */
+	actual := up.OutputHasEmailInRequestBody()
+
+	/* Assert */
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	if assert.NoError(t, actual) {
+		assert.Equal(t, expected, rec.Body.String())
+	}
+}

--- a/src/adapter/presenter/user_test.go
+++ b/src/adapter/presenter/user_test.go
@@ -24,6 +24,21 @@ func TestOutputCreateResult(t *testing.T) {
 	}
 }
 
+func TestOutputUpdateResult(t *testing.T) {
+	/* Arrange */
+	expected := "{}\n"
+	c, rec := newRouter()
+	up := &UserPresenter{c: c}
+
+	/* Act */
+	actual := up.OutputCreateResult()
+
+	/* Assert */
+	if assert.NoError(t, actual) {
+		assert.Equal(t, expected, rec.Body.String())
+	}
+}
+
 func TestOutputLoginResult(t *testing.T) {
 	/* Arrange */
 	expected := "{}\n"

--- a/src/driver/db/user.go
+++ b/src/driver/db/user.go
@@ -31,13 +31,32 @@ func (dbu *DbUserDriver) CreateUser(user *User) (*User, error) {
 	return user, err
 }
 
-func (dbu *DbUserDriver) FindByEmail(email string) error {
-	var user []*User
+func (dbu *DbUserDriver) FindByEmail(email string) (*User, error) {
+	var user *User
 	// Firstだと存在しない場合にサーバー側でエラーが発生してしまうため、Findでエラーを発生しないようにしている
 	result := DB.Where("email = ?", email).Find(&user)
 	// 存在しない場合にエラーは発生しないので、エラーを作成する
 	if result.RowsAffected == 0 {
-		return errors.New("user is not found")
+		return nil, errors.New("user is not found")
+	}
+	return user, nil
+}
+
+func (dbu *DbUserDriver) UpdateUser(user *User, updateColumns map[string]interface{}) error {
+	result := DB.Model(&user).Updates(updateColumns)
+	if err := result.Error; err != nil {
+		return err
 	}
 	return nil
+}
+
+func (dbu *DbUserDriver) GetUser(id int) (*User, error) {
+	var user *User
+	// Firstだと存在しない場合にサーバー側でエラーが発生してしまうため、Findでエラーを発生しないようにしている
+	result := DB.Find(&user, id)
+	// 存在しない場合にエラーは発生しないので、エラーを作成する
+	if result.RowsAffected == 0 {
+		return nil, errors.New("user is not found")
+	}
+	return user, nil
 }

--- a/src/driver/db/user.go
+++ b/src/driver/db/user.go
@@ -42,15 +42,15 @@ func (dbu *DbUserDriver) FindByEmail(email string) (*User, error) {
 	return user, nil
 }
 
-func (dbu *DbUserDriver) UpdateUser(user *User, updateColumns map[string]interface{}) error {
-	result := DB.Model(&user).Updates(updateColumns)
+func (dbu *DbUserDriver) UpdateUser(user *User, updateData map[string]interface{}) error {
+	result := DB.Model(&user).Updates(updateData)
 	if err := result.Error; err != nil {
 		return err
 	}
 	return nil
 }
 
-func (dbu *DbUserDriver) GetUser(id int) (*User, error) {
+func (dbu *DbUserDriver) FindById(id int) (*User, error) {
 	var user *User
 	// Firstだと存在しない場合にサーバー側でエラーが発生してしまうため、Findでエラーを発生しないようにしている
 	result := DB.Find(&user, id)

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -46,6 +46,6 @@ func (router *Router) Serve(ctx context.Context) {
 	router.echo.POST("/login", router.userController.LoginUser)
 	router.echo.GET("/auth", router.userController.GetAuthUrl)            // Google認証用のURLを取得し返す
 	router.echo.GET("/auth/signup", router.userController.SignupWithAuth) // ユーザの認証を確認し仮登録する(本登録は未実装,UpdateUserで行う)
-	router.echo.PATCH("/user", router.userController.UpdateUser)
+	router.echo.PUT("/user/:id", router.userController.UpdateUser)
 	router.echo.Logger.Fatal(router.echo.Start(":8080"))
 }

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -46,6 +46,6 @@ func (router *Router) Serve(ctx context.Context) {
 	router.echo.POST("/login", router.userController.LoginUser)
 	router.echo.GET("/auth", router.userController.GetAuthUrl)            // Google認証用のURLを取得し返す
 	router.echo.GET("/auth/signup", router.userController.SignupWithAuth) // ユーザの認証を確認し仮登録する(本登録は未実装,UpdateUserで行う)
-	// router.echo.PATCH("/user", router.userController.UpdateUser)
+	router.echo.PATCH("/user", router.userController.UpdateUser)
 	router.echo.Logger.Fatal(router.echo.Start(":8080"))
 }

--- a/src/entity/user.go
+++ b/src/entity/user.go
@@ -3,7 +3,6 @@ package model
 import (
 	"errors"
 	"regexp"
-	"strconv"
 )
 
 type User struct {
@@ -19,6 +18,8 @@ type UserCredentials struct {
 	Email string
 }
 
+type ChangeForUser map[string]interface{}
+
 func emailValid(email string) error {
 	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
 	re := regexp.MustCompile(emailRegex)
@@ -28,14 +29,14 @@ func emailValid(email string) error {
 	return nil
 }
 
-func ageValid(age int) error {
+func AgeValid(age int) error {
 	if age < 0 {
 		return errors.New("年齢が0未満です。")
 	}
 	return nil
 }
 
-func ageFormat(age int) int {
+func AgeFormat(age int) int {
 	// ageValidで0未満はエラーとなるので0未満は扱わない。
 	if age >= 60 {
 		return 60
@@ -43,7 +44,7 @@ func ageFormat(age int) int {
 	return (age / 10) * 10
 }
 
-func sexFormat(sex float32) float32 {
+func SexFormat(sex float32) float32 {
 	if sex < -1.0 {
 		return -1.0
 	}
@@ -53,7 +54,7 @@ func sexFormat(sex float32) float32 {
 	return sex
 }
 
-func genderFormat(gender float32) float32 {
+func GenderFormat(gender float32) float32 {
 	if gender < -1.0 {
 		return -1.0
 	}
@@ -66,7 +67,7 @@ func genderFormat(gender float32) float32 {
 func NewUser(name string, email string, age int, sex float32, gender float32) (*User, error) {
 	// バリデーションのチェック
 	emailValidError := emailValid(email)
-	ageValidError := ageValid(age)
+	ageValidError := AgeValid(age)
 	if err := errors.Join(emailValidError, ageValidError); err != nil {
 		return nil, err
 	}
@@ -74,9 +75,9 @@ func NewUser(name string, email string, age int, sex float32, gender float32) (*
 	user := &User{
 		Name:   name,
 		Email:  email,
-		Age:    ageFormat(age),
-		Sex:    sexFormat(sex),
-		Gender: genderFormat(gender),
+		Age:    AgeFormat(age),
+		Sex:    SexFormat(sex),
+		Gender: GenderFormat(gender),
 	}
 	return user, nil
 }
@@ -93,76 +94,19 @@ func NewUserCredentials(email string) (*UserCredentials, error) {
 	return user, nil
 }
 
-func UserFormat(data map[string]interface{}) (map[string]interface{}, error) {
-	formatedData := map[string]interface{}{}
-	// フォーマットの変換
-	// id
-	if id, ok := data["id"].(string); ok {
-		formatedData["id"], _ = strconv.Atoi(id)
-	} else if id, ok := data["id"].(float64); ok {
-		formatedData["id"] = int(id)
-	} else {
-		formatedData["id"] = data["id"]
-	}
-	// name
-	if name, ok := data["name"].(float64); ok {
-		formatedData["name"] = strconv.FormatFloat(name, 'f', -1, 64)
-	} else {
-		formatedData["name"] = data["name"]
-	}
-	// email
-	if email, ok := data["email"]; ok {
-		formatedData["email"] = email
-	}
-	// age
-	if age, ok := data["age"].(string); ok {
-		formatedData["age"], _ = strconv.Atoi(age)
-	} else if age, ok := data["age"].(float64); ok {
-		formatedData["age"] = int(age)
-	} else {
-		formatedData["age"] = data["age"]
-	}
-	// sex
-	if sex, ok := data["sex"].(string); ok {
-		formatedData["sex"], _ = strconv.ParseFloat(sex, 32)
-	} else if sex, ok := data["sex"].(float64); ok {
-		formatedData["sex"] = sexFormat(float32(sex))
-	} else {
-		formatedData["sex"] = data["sex"]
-	}
-	// gender
-	if gender, ok := data["gender"].(string); ok {
-		formatedData["gender"], _ = strconv.ParseFloat(gender, 32)
-	} else if gender, ok := data["gender"].(float64); ok {
-		formatedData["gender"] = genderFormat(float32(gender))
-	} else {
-		formatedData["gender"] = data["gender"]
-	}
+// func ValidateUser(emial: string, age) (map[string]interface{}, error) {
+// 	// バリデーションのチェック
+// 	var emailValidError error = nil
+// 	var ageValidError error = nil
+// 	if email, ok := formatedData["email"].(string); ok {
+// 		emailValidError = emailValid(email)
+// 	}
+// 	if age, ok := formatedData["age"].(int); ok {
+// 		ageValidError = AgeValid(age)
+// 	}
+// 	if err := errors.Join(emailValidError, ageValidError); err != nil {
+// 		return nil, err
+// 	}
 
-	// バリデーションのチェック
-	var emailValidError error = nil
-	var ageValidError error = nil
-	if email, ok := formatedData["email"].(string); ok {
-		emailValidError = emailValid(email)
-	}
-	if age, ok := formatedData["age"].(int); ok {
-		ageValidError = ageValid(age)
-	}
-	if err := errors.Join(emailValidError, ageValidError); err != nil {
-		return nil, err
-	}
-
-	return formatedData, nil
-}
-
-func UpdateConditions(data map[string]interface{}) error {
-	// idが含まれている
-	// emailは更新不可
-	if _, ok := data["id"]; !ok {
-		return errors.New("id is not found")
-	}
-	if _, ok := data["email"]; ok {
-		delete(data, "email")
-	}
-	return nil
-}
+// 	return formatedData, nil
+// }

--- a/src/entity/user.go
+++ b/src/entity/user.go
@@ -93,20 +93,3 @@ func NewUserCredentials(email string) (*UserCredentials, error) {
 	}
 	return user, nil
 }
-
-// func ValidateUser(emial: string, age) (map[string]interface{}, error) {
-// 	// バリデーションのチェック
-// 	var emailValidError error = nil
-// 	var ageValidError error = nil
-// 	if email, ok := formatedData["email"].(string); ok {
-// 		emailValidError = emailValid(email)
-// 	}
-// 	if age, ok := formatedData["age"].(int); ok {
-// 		ageValidError = AgeValid(age)
-// 	}
-// 	if err := errors.Join(emailValidError, ageValidError); err != nil {
-// 		return nil, err
-// 	}
-
-// 	return formatedData, nil
-// }

--- a/src/entity/user.go
+++ b/src/entity/user.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"regexp"
+	"strconv"
 )
 
 type User struct {
@@ -90,4 +91,78 @@ func NewUserCredentials(email string) (*UserCredentials, error) {
 		Email: email,
 	}
 	return user, nil
+}
+
+func UserFormat(data map[string]interface{}) (map[string]interface{}, error) {
+	formatedData := map[string]interface{}{}
+	// フォーマットの変換
+	// id
+	if id, ok := data["id"].(string); ok {
+		formatedData["id"], _ = strconv.Atoi(id)
+	} else if id, ok := data["id"].(float64); ok {
+		formatedData["id"] = int(id)
+	} else {
+		formatedData["id"] = data["id"]
+	}
+	// name
+	if name, ok := data["name"].(float64); ok {
+		formatedData["name"] = strconv.FormatFloat(name, 'f', -1, 64)
+	} else {
+		formatedData["name"] = data["name"]
+	}
+	// email
+	if email, ok := data["email"]; ok {
+		formatedData["email"] = email
+	}
+	// age
+	if age, ok := data["age"].(string); ok {
+		formatedData["age"], _ = strconv.Atoi(age)
+	} else if age, ok := data["age"].(float64); ok {
+		formatedData["age"] = int(age)
+	} else {
+		formatedData["age"] = data["age"]
+	}
+	// sex
+	if sex, ok := data["sex"].(string); ok {
+		formatedData["sex"], _ = strconv.ParseFloat(sex, 32)
+	} else if sex, ok := data["sex"].(float64); ok {
+		formatedData["sex"] = sexFormat(float32(sex))
+	} else {
+		formatedData["sex"] = data["sex"]
+	}
+	// gender
+	if gender, ok := data["gender"].(string); ok {
+		formatedData["gender"], _ = strconv.ParseFloat(gender, 32)
+	} else if gender, ok := data["gender"].(float64); ok {
+		formatedData["gender"] = genderFormat(float32(gender))
+	} else {
+		formatedData["gender"] = data["gender"]
+	}
+
+	// バリデーションのチェック
+	var emailValidError error = nil
+	var ageValidError error = nil
+	if email, ok := formatedData["email"].(string); ok {
+		emailValidError = emailValid(email)
+	}
+	if age, ok := formatedData["age"].(int); ok {
+		ageValidError = ageValid(age)
+	}
+	if err := errors.Join(emailValidError, ageValidError); err != nil {
+		return nil, err
+	}
+
+	return formatedData, nil
+}
+
+func UpdateConditions(data map[string]interface{}) error {
+	// idが含まれている
+	// emailは更新不可
+	if _, ok := data["id"]; !ok {
+		return errors.New("id is not found")
+	}
+	if _, ok := data["email"]; ok {
+		delete(data, "email")
+	}
+	return nil
 }

--- a/src/usecase/interactor/user.go
+++ b/src/usecase/interactor/user.go
@@ -3,7 +3,6 @@ package interactor
 import (
 	model "clean-storemap-api/src/entity"
 	port "clean-storemap-api/src/usecase/port"
-	"errors"
 )
 
 type UserInteractor struct {
@@ -32,7 +31,7 @@ func (ui *UserInteractor) CreateUser(user *model.User) error {
 func (ui *UserInteractor) UpdateUser(id int, updateData model.ChangeForUser) error {
 	// emailを更新しようとした場合にはエラーを返す
 	if _, ok := updateData["email"]; ok {
-		return errors.New("emailは更新できません")
+		return ui.userOutputPort.OutputHasEmailInRequestBody()
 	}
 	// 整形する
 	if age, ok := updateData["age"].(int); ok {

--- a/src/usecase/interactor/user.go
+++ b/src/usecase/interactor/user.go
@@ -28,6 +28,31 @@ func (ui *UserInteractor) CreateUser(user *model.User) error {
 	return nil
 }
 
+func (ui *UserInteractor) UpdateUser(updatedData map[string]interface{}) error {
+	// データの整形(entityのカラムの有効範囲に基づいて整形するので、controllerではなくusecaseで行う)
+	formatedData, err := model.UserFormat(updatedData)
+	if err != nil {
+		return err
+	}
+	// idを取得しidは更新しないので削除
+	id := formatedData["id"].(int)
+	delete(formatedData, "id")
+
+	// userが存在するか確認
+	user, err := ui.userRepository.Get(id)
+	if err != nil {
+		return err
+	}
+
+	if err := ui.userRepository.Update(user, formatedData); err != nil {
+		return err
+	}
+	if err := ui.userOutputPort.OutputUpdateResult(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (ui *UserInteractor) LoginUser(user *model.UserCredentials) error {
 	if err := ui.userRepository.FindBy(user); err != nil {
 		return err

--- a/src/usecase/interactor/user_test.go
+++ b/src/usecase/interactor/user_test.go
@@ -26,6 +26,14 @@ func (m *MockUserRepository) Exist(user *model.User) error {
 	args := m.Called()
 	return args.Error(0)
 }
+func (m *MockUserRepository) Update(*model.User, map[string]interface{}) error {
+	args := m.Called()
+	return args.Error(0)
+}
+func (m *MockUserRepository) Get(int) (*model.User, error) {
+	args := m.Called()
+	return args.Get(0).(*model.User), args.Error(1)
+}
 
 func (m *MockUserRepository) GenerateAuthUrl() string {
 	args := m.Called()
@@ -43,6 +51,11 @@ func (m *MockUserRepository) GetUserInfoWithAuthCode(string) (string, error) {
 }
 
 func (m *MockUserOutputPort) OutputCreateResult() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockUserOutputPort) OutputUpdateResult() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -88,6 +101,37 @@ func TestCreateUser(t *testing.T) {
 	assert.Equal(t, expected, actual)
 	mockUserRepository.AssertNumberOfCalls(t, "Create", 1)
 	mockUserOutputPort.AssertNumberOfCalls(t, "OutputCreateResult", 1)
+}
+
+func TestUpdateUser(t *testing.T) {
+	/* Arrange */
+	var expected error = nil
+	id := 1
+	existUser := &model.User{
+		Id:     id,
+		Name:   "sample",
+		Age:    10,
+		Sex:    0.1,
+		Gender: -0.1,
+	}
+	updatedColumns := map[string]interface{}{"id": 1, "name": "sample2", "sex": 1.0, "gender": -1.0}
+
+	mockUserRepository := new(MockUserRepository)
+	mockUserRepository.On("Get").Return(existUser, nil)
+	mockUserRepository.On("Update").Return(nil)
+	mockUserOutputPort := new(MockUserOutputPort)
+	mockUserOutputPort.On("OutputUpdateResult").Return(nil)
+
+	ui := &UserInteractor{userRepository: mockUserRepository, userOutputPort: mockUserOutputPort}
+
+	/* Act */
+	actual := ui.UpdateUser(updatedColumns)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockUserRepository.AssertNumberOfCalls(t, "Get", 1)
+	mockUserRepository.AssertNumberOfCalls(t, "Update", 1)
+	mockUserOutputPort.AssertNumberOfCalls(t, "OutputUpdateResult", 1)
 }
 
 func TestLoginUser(t *testing.T) {

--- a/src/usecase/interactor/user_test.go
+++ b/src/usecase/interactor/user_test.go
@@ -80,6 +80,11 @@ func (m *MockUserOutputPort) OutputAlreadySignedup() error {
 	return args.Error(0)
 }
 
+func (m *MockUserOutputPort) OutputHasEmailInRequestBody() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func TestCreateUser(t *testing.T) {
 	/* Arrange */
 	var expected error = nil
@@ -117,9 +122,10 @@ func TestUpdateUser(t *testing.T) {
 	updateData := model.ChangeForUser{"name": "sample2", "sex": 1.0, "gender": -1.0}
 
 	mockUserRepository := new(MockUserRepository)
+	mockUserOutputPort := new(MockUserOutputPort)
+	mockUserOutputPort.On("OutputHasEmailInRequestBody").Return(nil)
 	mockUserRepository.On("Get").Return(existUser, nil)
 	mockUserRepository.On("Update").Return(nil)
-	mockUserOutputPort := new(MockUserOutputPort)
 	mockUserOutputPort.On("OutputUpdateResult").Return(nil)
 
 	ui := &UserInteractor{userRepository: mockUserRepository, userOutputPort: mockUserOutputPort}

--- a/src/usecase/interactor/user_test.go
+++ b/src/usecase/interactor/user_test.go
@@ -26,7 +26,7 @@ func (m *MockUserRepository) Exist(user *model.User) error {
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockUserRepository) Update(*model.User, map[string]interface{}) error {
+func (m *MockUserRepository) Update(*model.User, model.ChangeForUser) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -114,7 +114,7 @@ func TestUpdateUser(t *testing.T) {
 		Sex:    0.1,
 		Gender: -0.1,
 	}
-	updatedColumns := map[string]interface{}{"id": 1, "name": "sample2", "sex": 1.0, "gender": -1.0}
+	updateData := model.ChangeForUser{"name": "sample2", "sex": 1.0, "gender": -1.0}
 
 	mockUserRepository := new(MockUserRepository)
 	mockUserRepository.On("Get").Return(existUser, nil)
@@ -125,7 +125,7 @@ func TestUpdateUser(t *testing.T) {
 	ui := &UserInteractor{userRepository: mockUserRepository, userOutputPort: mockUserOutputPort}
 
 	/* Act */
-	actual := ui.UpdateUser(updatedColumns)
+	actual := ui.UpdateUser(id, updateData)
 
 	/* Assert */
 	assert.Equal(t, expected, actual)

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -6,6 +6,7 @@ import (
 
 type UserInputPort interface {
 	CreateUser(*model.User) error
+	UpdateUser(map[string]interface{}) error
 	LoginUser(*model.UserCredentials) error
 	GetAuthUrl() error
 	SignupDraft(string) error
@@ -14,6 +15,8 @@ type UserInputPort interface {
 type UserRepository interface {
 	Exist(*model.User) error
 	Create(*model.User) (*model.User, error)
+	Update(*model.User, map[string]interface{}) error
+	Get(int) (*model.User, error)
 	FindBy(*model.UserCredentials) error
 	GenerateAuthUrl() string
 	GetUserInfoWithAuthCode(string) (string, error)
@@ -21,6 +24,7 @@ type UserRepository interface {
 
 type UserOutputPort interface {
 	OutputCreateResult() error
+	OutputUpdateResult() error
 	OutputLoginResult() error
 	OutputAuthUrl(string) error
 	OutputSignupWithAuth(int) error

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -29,4 +29,5 @@ type UserOutputPort interface {
 	OutputAuthUrl(string) error
 	OutputSignupWithAuth(int) error
 	OutputAlreadySignedup() error
+	OutputHasEmailInRequestBody() error
 }

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -6,7 +6,7 @@ import (
 
 type UserInputPort interface {
 	CreateUser(*model.User) error
-	UpdateUser(map[string]interface{}) error
+	UpdateUser(int, model.ChangeForUser) error
 	LoginUser(*model.UserCredentials) error
 	GetAuthUrl() error
 	SignupDraft(string) error
@@ -15,7 +15,7 @@ type UserInputPort interface {
 type UserRepository interface {
 	Exist(*model.User) error
 	Create(*model.User) (*model.User, error)
-	Update(*model.User, map[string]interface{}) error
+	Update(*model.User, model.ChangeForUser) error
 	Get(int) (*model.User, error)
 	FindBy(*model.UserCredentials) error
 	GenerateAuthUrl() string


### PR DESCRIPTION
authによりemailのみで仮登録を行うので、他のuserの情報(name,age等)を追加するためのupdate機能です。

### 動作確認手順
- userを作成する
- userのupdateを行う。

https://github.com/RinachanBoard31/clean-storemap-api/blob/2f849582c75863749847ddcebed5f38d63b92462/README.md?plain=1#L46-L56

### 注意
ユーザの作成後にmysqlで削除し、再度ユーザを作成するとidが2となるので、 ```curl -H "Content-Type: application/json" -X PATCH -d "@example/update_user_api_example.json" http://localhost:8080/user ```
ではエラーになります。(ファイル内でid=1としているため)