### PR TITLE
favorite_storesテーブルにお気に入りのお店情報を保存

### DIFF
--- a/example/post_stores_favorite.json
+++ b/example/post_stores_favorite.json
@@ -1,0 +1,9 @@
+{
+    "userId": 1,
+    "storeId": "Id002",
+    "storeName": "UEC cafe",
+    "regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+    "priceLevel": "PRICE_LEVEL_MODERATE",
+    "latitude": "35.713",
+    "longitude": "139.762"
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.4
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.12.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.6.0 h1:HBkoIh4BdSxoyo9PveV8giw7ZsaBOvzWKfcg/6MrVwI=
 github.com/google/wire v0.6.0/go.mod h1:F4QhpQ9EDIdJ1Mbop/NZBRB+5yrR6qg3BnctaoUk6NA=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -22,6 +22,7 @@ type StoreRequestBody struct {
 type StoreI interface {
 	GetStores(c echo.Context) error
 	GetNearStores(c echo.Context) error
+	SaveFavoriteStore(c echo.Context) error
 }
 
 type StoreOutputFactory func(echo.Context) port.StoreOutputPort

--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -11,8 +11,9 @@ import (
 )
 
 type StoreRequestBody struct {
-	Id                  string `json:"id" validate:"required"`
-	Name                string `json:"name" validate:"required"`
+	UserId              string `json:"userId" validate:"required"`
+	StoreId             string `json:"storeId" validate:"required"`
+	StoreName           string `json:"storeName" validate:"required"`
 	RegularOpeningHours string `json:"regularOpeningHours"`
 	PriceLevel          string `json:"priceLevel"`
 	Latitude            string `json:"latitude" validate:"required"`
@@ -71,11 +72,11 @@ func (sc *StoreController) SaveFavoriteStore(c echo.Context) error {
 	if err := c.Validate(&s); err != nil {
 		return c.JSON(http.StatusInternalServerError, err.(validator.ValidationErrors).Error())
 	}
-	store, err := model.NewStore(s.Id, s.Name, s.RegularOpeningHours, s.PriceLevel, s.Latitude, s.Longitude)
+	store, err := model.NewStore(s.StoreId, s.StoreName, s.RegularOpeningHours, s.PriceLevel, s.Latitude, s.Longitude)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
-	return sc.newStoreInputPort(c).SaveFavoriteStore(store)
+	return sc.newStoreInputPort(c).SaveFavoriteStore(store, s.UserId)
 }
 
 /* ここでpresenterにecho.Contextを渡している！起爆！！！（遅延） */

--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -5,13 +5,13 @@ import (
 	model "clean-storemap-api/src/entity"
 	"clean-storemap-api/src/usecase/port"
 	"net/http"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"gopkg.in/go-playground/validator.v9"
 )
 
 type StoreRequestBody struct {
-	UserId              int    `json:"userId" validate:"required"`
 	StoreId             string `json:"storeId" validate:"required"`
 	StoreName           string `json:"storeName" validate:"required"`
 	RegularOpeningHours string `json:"regularOpeningHours"`
@@ -66,6 +66,15 @@ func (sc *StoreController) GetNearStores(c echo.Context) error {
 
 func (sc *StoreController) SaveFavoriteStore(c echo.Context) error {
 	var s StoreRequestBody
+	userIdParam := c.Param("user_id")
+	if userIdParam == "" {
+		return c.JSON(http.StatusBadRequest, "user_id is required")
+	}
+	userId, err := strconv.Atoi(userIdParam)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, "user_id must be a valid integer")
+	}
+
 	if err := c.Bind(&s); err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
@@ -76,7 +85,7 @@ func (sc *StoreController) SaveFavoriteStore(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
-	return sc.newStoreInputPort(c).SaveFavoriteStore(store, s.UserId)
+	return sc.newStoreInputPort(c).SaveFavoriteStore(store, userId)
 }
 
 /* ここでpresenterにecho.Contextを渡している！起爆！！！（遅延） */

--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -11,7 +11,7 @@ import (
 )
 
 type StoreRequestBody struct {
-	UserId              string `json:"userId" validate:"required"`
+	UserId              int    `json:"userId" validate:"required"`
 	StoreId             string `json:"storeId" validate:"required"`
 	StoreName           string `json:"storeName" validate:"required"`
 	RegularOpeningHours string `json:"regularOpeningHours"`

--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -61,6 +61,10 @@ func (sc *StoreController) GetNearStores(c echo.Context) error {
 	return sc.newStoreInputPort(c).GetNearStores()
 }
 
+func (sc *StoreController) SaveFavoriteStore(c echo.Context) error {
+	return sc.newStoreInputPort(c).SaveFavoriteStore()
+}
+
 /* ここでpresenterにecho.Contextを渡している！起爆！！！（遅延） */
 /* これによって、presenterのinterface(outputport)にecho.Contextを書かなくて良くなる */
 func (sc *StoreController) newStoreInputPort(c echo.Context) port.StoreInputPort {

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bytes"
 	"clean-storemap-api/src/adapter/gateway"
 	api "clean-storemap-api/src/driver/api"
 	db "clean-storemap-api/src/driver/db"
@@ -81,7 +82,7 @@ func (m *MockStoreInputFactoryFuncObject) GetNearStores() error {
 	return args.Error(0)
 }
 
-func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore() error {
+func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(*model.Store) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -171,10 +172,23 @@ func TestGetNearStores(t *testing.T) {
 	mockStoreInputFactoryFuncObject.AssertNumberOfCalls(t, "GetNearStores", 1)
 }
 
-func TestSaveStore(t *testing.T) {
+func TestFavoriteSaveStore(t *testing.T) {
 	/* Arrange */
 	c, rec := newRouter()
 	expected := errors.New("")
+
+	reqBody := `{
+		"id": "Id001",
+		"name": "UEC cafe",
+		"regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+		"priceLevel": "PRICE_LEVEL_MODERATE",
+		"latitude": "35.713",
+		"longitude": "139.762"
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/favorite-store", bytes.NewBufferString(reqBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c.SetRequest(req)
 
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("GetStores").Return([]*db.FavoriteStore{}, nil)

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -44,6 +44,11 @@ func (m *MockStoreDriverFactory) GetStores() ([]*db.FavoriteStore, error) {
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
+func (m *MockStoreDriverFactory) FindFavorite(string, int) (*db.FavoriteStore, error) {
+	args := m.Called()
+	return args.Get(0).(*db.FavoriteStore), args.Error(1)
+}
+
 func (m *MockStoreDriverFactory) SaveStore(*db.FavoriteStore) error {
 	args := m.Called()
 	return args.Error(0)
@@ -64,6 +69,11 @@ func (m *MockStoreOutputFactoryFuncObject) OutputSaveFavoriteStoreResult() error
 	return args.Error(0)
 }
 
+func (m *MockStoreOutputFactoryFuncObject) OutputAlreadyExistFavorite() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func mockStoreOutputFactoryFunc(c echo.Context) port.StoreOutputPort {
 	return &MockStoreOutputFactoryFuncObject{}
 }
@@ -78,7 +88,12 @@ func (m *MockStoreRepositoryFactoryFuncObject) GetNearStores() ([]*model.Store, 
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId string) error {
+func (m *MockStoreRepositoryFactoryFuncObject) ExistFavorite(store *model.Store, userId int) (bool, error) {
+	args := m.Called(store, userId)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId int) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -97,7 +112,7 @@ func (m *MockStoreInputFactoryFuncObject) GetNearStores() error {
 	return args.Error(0)
 }
 
-func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId string) error {
+func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId int) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -194,7 +209,7 @@ func TestFavoriteSaveStore(t *testing.T) {
 	c, rec := newRouter()
 
 	reqBody := `{
-		"userId": "test@example.com",
+		"userId": 1,
 		"storeId": "Id001",
 		"storeName": "UEC cafe",
 		"regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -78,7 +78,7 @@ func (m *MockStoreRepositoryFactoryFuncObject) GetNearStores() ([]*model.Store, 
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(*model.Store) error {
+func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId string) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -97,7 +97,7 @@ func (m *MockStoreInputFactoryFuncObject) GetNearStores() error {
 	return args.Error(0)
 }
 
-func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(*model.Store) error {
+func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId string) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -194,8 +194,9 @@ func TestFavoriteSaveStore(t *testing.T) {
 	c, rec := newRouter()
 
 	reqBody := `{
-		"id": "Id001",
-		"name": "UEC cafe",
+		"userId": "test@example.com",
+		"storeId": "Id001",
+		"storeName": "UEC cafe",
 		"regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 		"priceLevel": "PRICE_LEVEL_MODERATE",
 		"latitude": "35.713",

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -209,7 +209,6 @@ func TestFavoriteSaveStore(t *testing.T) {
 	c, rec := newRouter()
 
 	reqBody := `{
-		"userId": 1,
 		"storeId": "Id001",
 		"storeName": "UEC cafe",
 		"regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
@@ -218,9 +217,11 @@ func TestFavoriteSaveStore(t *testing.T) {
 		"longitude": "139.762"
 	}`
 
-	req := httptest.NewRequest(http.MethodPost, "/favorite-store", bytes.NewBufferString(reqBody))
+	req := httptest.NewRequest(http.MethodPost, "/user/:user_id/favorite-store", bytes.NewBufferString(reqBody))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c.SetRequest(req)
+	c.SetParamNames("user_id")
+	c.SetParamValues("1")
 
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("GetStores").Return([]*db.FavoriteStore{}, nil)

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -44,12 +44,22 @@ func (m *MockStoreDriverFactory) GetStores() ([]*db.FavoriteStore, error) {
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
+func (m *MockStoreDriverFactory) SaveStore(*db.FavoriteStore) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *MockGoogleMapDriverFactory) GetStores() ([]*api.Store, error) {
 	args := m.Called()
 	return args.Get(0).([]*api.Store), args.Error(1)
 }
 
 func (m *MockStoreOutputFactoryFuncObject) OutputAllStores([]*model.Store) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStoreOutputFactoryFuncObject) OutputSaveFavoriteStoreResult() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -66,6 +76,11 @@ func (m *MockStoreRepositoryFactoryFuncObject) GetAll() ([]*model.Store, error) 
 func (m *MockStoreRepositoryFactoryFuncObject) GetNearStores() ([]*model.Store, error) {
 	args := m.Called()
 	return args.Get(0).([]*model.Store), args.Error(1)
+}
+
+func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(*model.Store) error {
+	args := m.Called()
+	return args.Error(0)
 }
 
 func mockStoreRepositoryFactoryFunc(storeDriver gateway.StoreDriver, googleMapDriver gateway.GoogleMapDriver) port.StoreRepository {
@@ -116,6 +131,7 @@ func TestGetStores(t *testing.T) {
 	// Driverだけは実体が必要
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("GetStores").Return([]*db.FavoriteStore{}, nil)
+	mockStoreDriverFactory.On("SaveStore").Return(nil)
 
 	// InputPortのGetStoresのモックを作成
 	sc := &StoreController{
@@ -174,8 +190,8 @@ func TestGetNearStores(t *testing.T) {
 
 func TestFavoriteSaveStore(t *testing.T) {
 	/* Arrange */
+	var expected error = nil
 	c, rec := newRouter()
-	expected := errors.New("")
 
 	reqBody := `{
 		"id": "Id001",
@@ -192,6 +208,7 @@ func TestFavoriteSaveStore(t *testing.T) {
 
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("GetStores").Return([]*db.FavoriteStore{}, nil)
+	mockStoreDriverFactory.On("SaveStore").Return(nil)
 
 	sc := &StoreController{
 		storeDriverFactory:     mockStoreDriverFactory,
@@ -200,7 +217,7 @@ func TestFavoriteSaveStore(t *testing.T) {
 	}
 
 	mockStoreInputFactoryFuncObject := new(MockStoreInputFactoryFuncObject)
-	mockStoreInputFactoryFuncObject.On("SaveFavoriteStore").Return(expected)
+	mockStoreInputFactoryFuncObject.On("SaveFavoriteStore").Return(nil)
 	sc.storeInputFactory = func(repository port.StoreRepository, output port.StoreOutputPort) port.StoreInputPort {
 		return mockStoreInputFactoryFuncObject
 	}

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -17,6 +17,7 @@ type StoreGateway struct {
 
 type StoreDriver interface {
 	GetStores() ([]*db.FavoriteStore, error)
+	SaveStore(*db.FavoriteStore) error
 }
 
 type GoogleMapDriver interface {
@@ -70,4 +71,22 @@ func (sg *StoreGateway) GetNearStores() ([]*model.Store, error) {
 		})
 	}
 	return stores, nil
+}
+
+func (sg *StoreGateway) SaveFavoriteStore(store *model.Store) error {
+	dbStore := &db.FavoriteStore{
+		Id:                  store.Id,
+		Name:                store.Name,
+		RegularOpeningHours: store.RegularOpeningHours,
+		PriceLevel:          store.PriceLevel,
+		Latitude:            store.Location.Lat,
+		Longitude:           store.Location.Lng,
+	}
+
+	err := sg.storeDriver.SaveStore(dbStore)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -7,6 +7,8 @@ import (
 	"clean-storemap-api/src/usecase/port"
 	"fmt"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // Dbの要素を構造体として渡す必要がある。
@@ -40,7 +42,7 @@ func (sg *StoreGateway) GetAll() ([]*model.Store, error) {
 	for _, v := range dbStores {
 		stores = append(stores, &model.Store{
 			Id:                  v.Id,
-			Name:                v.Name,
+			Name:                v.StoreName,
 			RegularOpeningHours: v.RegularOpeningHours,
 			PriceLevel:          v.PriceLevel,
 			Location: model.Location{
@@ -73,10 +75,12 @@ func (sg *StoreGateway) GetNearStores() ([]*model.Store, error) {
 	return stores, nil
 }
 
-func (sg *StoreGateway) SaveFavoriteStore(store *model.Store) error {
+func (sg *StoreGateway) SaveFavoriteStore(store *model.Store, userId string) error {
 	dbStore := &db.FavoriteStore{
-		Id:                  store.Id,
-		Name:                store.Name,
+		Id:                  uuid.New().String(),
+		UserId:              userId,
+		StoreId:             store.Id,
+		StoreName:           store.Name,
 		RegularOpeningHours: store.RegularOpeningHours,
 		PriceLevel:          store.PriceLevel,
 		Latitude:            store.Location.Lat,

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -16,7 +16,7 @@ type StoreGateway struct {
 }
 
 type StoreDriver interface {
-	GetStores() ([]*db.Store, error)
+	GetStores() ([]*db.FavoriteStore, error)
 }
 
 type GoogleMapDriver interface {

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -19,6 +19,7 @@ type StoreGateway struct {
 
 type StoreDriver interface {
 	GetStores() ([]*db.FavoriteStore, error)
+	FindFavorite(storeId string, userId int) (*db.FavoriteStore, error)
 	SaveStore(*db.FavoriteStore) error
 }
 
@@ -75,7 +76,15 @@ func (sg *StoreGateway) GetNearStores() ([]*model.Store, error) {
 	return stores, nil
 }
 
-func (sg *StoreGateway) SaveFavoriteStore(store *model.Store, userId string) error {
+func (sg *StoreGateway) ExistFavorite(store *model.Store, userId int) (bool, error) {
+	_, err := sg.storeDriver.FindFavorite(store.Id, userId)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (sg *StoreGateway) SaveFavoriteStore(store *model.Store, userId int) error {
 	dbStore := &db.FavoriteStore{
 		Id:                  uuid.New().String(),
 		UserId:              userId,
@@ -94,3 +103,6 @@ func (sg *StoreGateway) SaveFavoriteStore(store *model.Store, userId string) err
 
 	return nil
 }
+
+// DoesDuplicateFavorite()
+// -> storeId && userIdが favorite store tableに存在するかどうかを確認する

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -77,8 +77,11 @@ func (sg *StoreGateway) GetNearStores() ([]*model.Store, error) {
 }
 
 func (sg *StoreGateway) ExistFavorite(store *model.Store, userId int) (bool, error) {
-	_, err := sg.storeDriver.FindFavorite(store.Id, userId)
+	dbStore, err := sg.storeDriver.FindFavorite(store.Id, userId)
 	if err != nil {
+		return false, err
+	}
+	if dbStore == nil {
 		return false, nil
 	}
 	return true, nil

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -59,6 +59,11 @@ func (m *MockStoreRepository) GetStores() ([]*db.FavoriteStore, error) {
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
+func (m *MockStoreRepository) SaveStore(*db.FavoriteStore) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 type MockGoogleMapRepository struct {
 	mock.Mock
 }
@@ -137,4 +142,26 @@ func TestGetNearStores(t *testing.T) {
 	/* Assert */
 	assert.Equal(t, expected, actual)
 	mockGoogleMapRepository.AssertNumberOfCalls(t, "GetStores", 1)
+}
+
+func TestSaveFavoriteStore(t *testing.T) {
+	/* Arrange */
+	var expected error = nil
+	mockStoreRepository := new(MockStoreRepository)
+	mockStoreRepository.On("SaveStore").Return(nil)
+	sg := &StoreGateway{storeDriver: mockStoreRepository}
+	store := &model.Store{
+		Id:                  "Id001",
+		Name:                "UEC cafe",
+		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+		PriceLevel:          "PRICE_LEVEL_MODERATE",
+		Location:            model.Location{Lat: "35.713", Lng: "139.762"},
+	}
+
+	/* Act */
+	actual := sg.SaveFavoriteStore(store)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockStoreRepository.AssertNumberOfCalls(t, "SaveStore", 1)
 }

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -59,6 +59,11 @@ func (m *MockStoreRepository) GetStores() ([]*db.FavoriteStore, error) {
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
+func (m *MockStoreRepository) FindFavorite(storeId string, userId int) (*db.FavoriteStore, error) {
+	args := m.Called(storeId, userId)
+	return args.Get(0).(*db.FavoriteStore), args.Error(1)
+}
+
 func (m *MockStoreRepository) SaveStore(dbStore *db.FavoriteStore) error {
 	args := m.Called(dbStore)
 	return args.Error(0)
@@ -150,7 +155,7 @@ func TestSaveFavoriteStore(t *testing.T) {
 	mockStoreRepository := new(MockStoreRepository)
 	mockStoreRepository.On("SaveStore", mock.MatchedBy(func(dbStore *db.FavoriteStore) bool {
 		// UUIDはテストで完全一致が不可能なため、dbStore.id以外のフィールドを検証
-		return dbStore.UserId == "test@example.com" &&
+		return dbStore.UserId == 1 &&
 			dbStore.StoreId == "Id001" &&
 			dbStore.StoreName == "UEC cafe" &&
 			dbStore.RegularOpeningHours == "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00" &&
@@ -167,7 +172,7 @@ func TestSaveFavoriteStore(t *testing.T) {
 		PriceLevel:          "PRICE_LEVEL_MODERATE",
 		Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 	}
-	userId := "test@example.com"
+	userId := 1
 
 	/* Act */
 	actual := sg.SaveFavoriteStore(store, userId)

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func makeDummyDbStores() ([]*db.Store, error) {
-	dummyStores := make([]*db.Store, 0)
-	dummyStores = append(dummyStores, &db.Store{
+func makeDummyDbStores() ([]*db.FavoriteStore, error) {
+	dummyStores := make([]*db.FavoriteStore, 0)
+	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "Id001",
 		Name:                "UEC cafe",
 		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
@@ -20,7 +20,7 @@ func makeDummyDbStores() ([]*db.Store, error) {
 		Latitude:            "35.713",
 		Longitude:           "139.762",
 	})
-	dummyStores = append(dummyStores, &db.Store{
+	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "Id002",
 		Name:                "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
@@ -54,9 +54,9 @@ type MockStoreRepository struct {
 	mock.Mock
 }
 
-func (m *MockStoreRepository) GetStores() ([]*db.Store, error) {
+func (m *MockStoreRepository) GetStores() ([]*db.FavoriteStore, error) {
 	args := m.Called()
-	return args.Get(0).([]*db.Store), args.Error(1)
+	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
 type MockGoogleMapRepository struct {

--- a/src/adapter/presenter/store.go
+++ b/src/adapter/presenter/store.go
@@ -54,3 +54,8 @@ func (sp *StorePresenter) OutputAllStores(stores []*model.Store) error {
 func (sp *StorePresenter) OutputSaveFavoriteStoreResult() error {
 	return sp.c.JSON(http.StatusOK, map[string]interface{}{})
 }
+
+func (sp *StorePresenter) OutputAlreadyExistFavorite() error {
+	errMsg := "Already exist favorite store"
+	return sp.c.JSON(http.StatusConflict, map[string]interface{}{"error": errMsg})
+}

--- a/src/adapter/presenter/store.go
+++ b/src/adapter/presenter/store.go
@@ -50,3 +50,7 @@ func (sp *StorePresenter) OutputAllStores(stores []*model.Store) error {
 	output_json := &StoreOutputJson{Stores: json_stores}
 	return sp.c.JSON(http.StatusOK, output_json)
 }
+
+func (sp *StorePresenter) OutputSaveFavoriteStoreResult() error {
+	return sp.c.JSON(http.StatusOK, map[string]interface{}{})
+}

--- a/src/adapter/presenter/store_test.go
+++ b/src/adapter/presenter/store_test.go
@@ -62,3 +62,19 @@ func TestOutputSaveFavoriteStoreResult(t *testing.T) {
 		assert.Equal(t, expected, rec.Body.String())
 	}
 }
+
+func TestOutputAlreadyExistFavorite(t *testing.T) {
+	/* Arrange */
+	expected := "{\"error\":\"Already exist favorite store\"}\n"
+	c, rec := newRouter()
+	sp := &StorePresenter{c: c}
+
+	/* Act */
+	actual := sp.OutputAlreadyExistFavorite()
+
+	/* Assert */
+	// sp.OutputAlreadyExistFavorite()がJSONを返すこと
+	if assert.NoError(t, actual) {
+		assert.Equal(t, expected, rec.Body.String())
+	}
+}

--- a/src/adapter/presenter/store_test.go
+++ b/src/adapter/presenter/store_test.go
@@ -46,3 +46,19 @@ func TestOutputAllStores(t *testing.T) {
 		assert.Equal(t, expected, rec.Body.String())
 	}
 }
+
+func TestOutputSaveFavoriteStoreResult(t *testing.T) {
+	/* Arrange */
+	expected := "{}\n"
+	c, rec := newRouter()
+	sp := &StorePresenter{c: c}
+
+	/* Act */
+	actual := sp.OutputSaveFavoriteStoreResult()
+
+	/* Assert */
+	// sp.OutputSaveFavoriteStoreResult()がJSONを返すこ
+	if assert.NoError(t, actual) {
+		assert.Equal(t, expected, rec.Body.String())
+	}
+}

--- a/src/driver/db/initdb.go
+++ b/src/driver/db/initdb.go
@@ -9,6 +9,7 @@ import (
 )
 
 var DB *gorm.DB
+
 func InitDB() {
 	dsn := os.Getenv("TESTDB_CONNECTION")
 
@@ -20,6 +21,6 @@ func InitDB() {
 	}
 
 	// ここで使用するすべての構造体をMigrate
-	DB.AutoMigrate(&Store{})
+	DB.AutoMigrate(&FavoriteStore{})
 	DB.AutoMigrate(&User{})
 }

--- a/src/driver/db/initdb.go
+++ b/src/driver/db/initdb.go
@@ -20,7 +20,13 @@ func InitDB() {
 		log.Fatalf("failed to connect database: %v", err)
 	}
 
-	// ここで使用するすべての構造体をMigrate
-	DB.AutoMigrate(&FavoriteStore{})
-	DB.AutoMigrate(&User{})
+	// Userテーブルを先に作成する必要がある
+	if err := DB.AutoMigrate(&User{}); err != nil {
+		log.Fatalf("failed to migrate User: %v", err)
+	}
+
+	// FavoriteStoreテーブルを作成
+	if err := DB.AutoMigrate(&FavoriteStore{}); err != nil {
+		log.Fatalf("failed to migrate FavoriteStore: %v", err)
+	}
 }

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -11,7 +11,7 @@ func NewStoreDriver() *DbStoreDriver {
 }
 
 /* interfaceと型は同義。仮にgatewayがDBの型を知ったとしても、どんなDBから来たかわかるわけではないのでおk */
-type Store struct {
+type FavoriteStore struct {
 	Id                  string `gorm:"primaryKey"`
 	Name                string
 	RegularOpeningHours string
@@ -22,8 +22,8 @@ type Store struct {
 	UpdatedAt           time.Time
 }
 
-func (dbs *DbStoreDriver) GetStores() ([]*Store, error) {
-	var stores []*Store
+func (dbs *DbStoreDriver) GetStores() ([]*FavoriteStore, error) {
+	var stores []*FavoriteStore
 	err := DB.Find(&stores).Error
 	if err != nil {
 		return nil, err

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -30,3 +30,11 @@ func (dbs *DbStoreDriver) GetStores() ([]*FavoriteStore, error) {
 	}
 	return stores, nil
 }
+
+func (dbs *DbStoreDriver) SaveStore(store *FavoriteStore) error {
+	err := DB.Create(&store).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -1,7 +1,10 @@
 package db
 
 import (
+	"errors"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type DbStoreDriver struct{}
@@ -38,6 +41,9 @@ func (dbs *DbStoreDriver) FindFavorite(storeId string, userId int) (*FavoriteSto
 	var store FavoriteStore
 	err := DB.Where("store_id = ? AND user_id = ?", storeId, userId).First(&store).Error
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return &store, nil

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -1,10 +1,7 @@
 package db
 
 import (
-	"errors"
 	"time"
-
-	"gorm.io/gorm"
 )
 
 type DbStoreDriver struct{}
@@ -38,15 +35,16 @@ func (dbs *DbStoreDriver) GetStores() ([]*FavoriteStore, error) {
 }
 
 func (dbs *DbStoreDriver) FindFavorite(storeId string, userId int) (*FavoriteStore, error) {
-	var store FavoriteStore
-	err := DB.Where("store_id = ? AND user_id = ?", storeId, userId).First(&store).Error
+	var stores []FavoriteStore
+	err := DB.Where("store_id = ? AND user_id = ?", storeId, userId).Find(&stores).Error
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
 		return nil, err
 	}
-	return &store, nil
+	if len(stores) == 0 {
+		return nil, nil
+	}
+
+	return &stores[0], nil
 }
 
 func (dbs *DbStoreDriver) SaveStore(dbStore *FavoriteStore) error {

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -14,6 +14,7 @@ func NewStoreDriver() *DbStoreDriver {
 type FavoriteStore struct {
 	Id                  string `gorm:"primaryKey"`
 	UserId              int    `gorm:"not null"`
+	User                User   `gorm:"foreignKey:UserId;references:Id"`
 	StoreId             string `gorm:"not null"`
 	StoreName           string `gorm:"not null"`
 	RegularOpeningHours string

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -13,7 +13,7 @@ func NewStoreDriver() *DbStoreDriver {
 /* interfaceと型は同義。仮にgatewayがDBの型を知ったとしても、どんなDBから来たかわかるわけではないのでおk */
 type FavoriteStore struct {
 	Id                  string `gorm:"primaryKey"`
-	UserId              string `gorm:"not null"`
+	UserId              int    `gorm:"not null"`
 	StoreId             string `gorm:"not null"`
 	StoreName           string `gorm:"not null"`
 	RegularOpeningHours string
@@ -31,6 +31,15 @@ func (dbs *DbStoreDriver) GetStores() ([]*FavoriteStore, error) {
 		return nil, err
 	}
 	return stores, nil
+}
+
+func (dbs *DbStoreDriver) FindFavorite(storeId string, userId int) (*FavoriteStore, error) {
+	var store FavoriteStore
+	err := DB.Where("store_id = ? AND user_id = ?", storeId, userId).First(&store).Error
+	if err != nil {
+		return nil, err
+	}
+	return &store, nil
 }
 
 func (dbs *DbStoreDriver) SaveStore(dbStore *FavoriteStore) error {

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -13,11 +13,11 @@ func NewStoreDriver() *DbStoreDriver {
 /* interfaceと型は同義。仮にgatewayがDBの型を知ったとしても、どんなDBから来たかわかるわけではないのでおk */
 type FavoriteStore struct {
 	Id                  string `gorm:"primaryKey"`
-	Name                string
+	Name                string `gorm:"not null"`
 	RegularOpeningHours string
 	PriceLevel          string
-	Latitude            string
-	Longitude           string
+	Latitude            string `gorm:"not null"`
+	Longitude           string `gorm:"not null"`
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 }

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -13,7 +13,9 @@ func NewStoreDriver() *DbStoreDriver {
 /* interfaceと型は同義。仮にgatewayがDBの型を知ったとしても、どんなDBから来たかわかるわけではないのでおk */
 type FavoriteStore struct {
 	Id                  string `gorm:"primaryKey"`
-	Name                string `gorm:"not null"`
+	UserId              string `gorm:"not null"`
+	StoreId             string `gorm:"not null"`
+	StoreName           string `gorm:"not null"`
 	RegularOpeningHours string
 	PriceLevel          string
 	Latitude            string `gorm:"not null"`
@@ -31,8 +33,8 @@ func (dbs *DbStoreDriver) GetStores() ([]*FavoriteStore, error) {
 	return stores, nil
 }
 
-func (dbs *DbStoreDriver) SaveStore(store *FavoriteStore) error {
-	err := DB.Create(&store).Error
+func (dbs *DbStoreDriver) SaveStore(dbStore *FavoriteStore) error {
+	err := DB.Create(&dbStore).Error
 	if err != nil {
 		return err
 	}

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -42,7 +42,7 @@ func NewRouter(echo *echo.Echo, storeController controller.StoreI, userControlle
 func (router *Router) Serve(ctx context.Context) {
 	router.echo.GET("/", router.storeController.GetStores)
 	router.echo.GET("/stores/opening-hours", router.storeController.GetNearStores)
-	router.echo.POST("/stores/favorite", router.storeController.SaveFavoriteStore)
+	router.echo.POST("/user/:user_id/favorite-store", router.storeController.SaveFavoriteStore)
 	router.echo.POST("/user", router.userController.CreateUser) // こっちは時期に使わなくなります。
 	router.echo.POST("/login", router.userController.LoginUser)
 	router.echo.GET("/auth", router.userController.GetAuthUrl)            // Google認証用のURLを取得し返す

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -42,6 +42,7 @@ func NewRouter(echo *echo.Echo, storeController controller.StoreI, userControlle
 func (router *Router) Serve(ctx context.Context) {
 	router.echo.GET("/", router.storeController.GetStores)
 	router.echo.GET("/stores/opening-hours", router.storeController.GetNearStores)
+	router.echo.POST("/stores/favorite", router.storeController.SaveFavoriteStore)
 	router.echo.POST("/user", router.userController.CreateUser)
 	router.echo.POST("/login", router.userController.LoginUser)
 	router.echo.GET("/auth", router.userController.GetAuthUrl) // Google認証用のURLを取得し返す(ユーザの登録はsignupで行う)

--- a/src/entity/store.go
+++ b/src/entity/store.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"errors"
+	"strconv"
+)
+
 type Location struct {
 	Lat string
 	Lng string
@@ -11,4 +16,44 @@ type Store struct {
 	RegularOpeningHours string
 	PriceLevel          string
 	Location            Location
+}
+
+func (l Location) Validate() error {
+	// 緯度が-90から90の間にあるかチェック
+	lat, err := strconv.ParseFloat(l.Lat, 64)
+	if err != nil {
+		return errors.New("latitude is invalid")
+	}
+	if lat < -90 || lat > 90 {
+		return errors.New("latitude must be between -90 and 90, got " + l.Lat)
+	}
+
+	// 経度が-180から180の間にあるかチェック
+	lng, err := strconv.ParseFloat(l.Lng, 64)
+	if err != nil {
+		return errors.New("longitude is invalid")
+	}
+	if lng < -180 || lng > 180 {
+		return errors.New("longitude must be between -180 and 180, got " + l.Lng)
+	}
+
+	return nil
+}
+
+func NewStore(id string, name string, regularOpeningHours string, priceLevel string, lat string, lng string) (*Store, error) {
+	location := Location{Lat: lat, Lng: lng}
+
+	if err := location.Validate(); err != nil {
+		return nil, err
+	}
+
+	store := &Store{
+		Id:                  id,
+		Name:                name,
+		RegularOpeningHours: regularOpeningHours,
+		PriceLevel:          priceLevel,
+		Location:            location,
+	}
+
+	return store, nil
 }

--- a/src/entity/user.go
+++ b/src/entity/user.go
@@ -5,8 +5,10 @@ import (
 	"regexp"
 )
 
+// type UserId string
+
 type User struct {
-	Id     int
+	Id     int // TODO: UserIdに変更したい
 	Name   string
 	Email  string
 	Age    int     // xx代として表記する(60代以上は全て60とする)

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -33,8 +33,8 @@ func (si *StoreInteractor) GetNearStores() error {
 	return si.storeOutputPort.OutputAllStores(places)
 }
 
-func (si *StoreInteractor) SaveFavoriteStore(store *model.Store) error {
-	if err := si.storeRepository.SaveFavoriteStore(store); err != nil {
+func (si *StoreInteractor) SaveFavoriteStore(store *model.Store, userId string) error {
+	if err := si.storeRepository.SaveFavoriteStore(store, userId); err != nil {
 		return err
 	}
 	if err := si.storeOutputPort.OutputSaveFavoriteStoreResult(); err != nil {

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -34,5 +34,11 @@ func (si *StoreInteractor) GetNearStores() error {
 }
 
 func (si *StoreInteractor) SaveFavoriteStore(store *model.Store) error {
+	if err := si.storeRepository.SaveFavoriteStore(store); err != nil {
+		return err
+	}
+	if err := si.storeOutputPort.OutputSaveFavoriteStoreResult(); err != nil {
+		return err
+	}
 	return nil
 }

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -33,7 +33,14 @@ func (si *StoreInteractor) GetNearStores() error {
 	return si.storeOutputPort.OutputAllStores(places)
 }
 
-func (si *StoreInteractor) SaveFavoriteStore(store *model.Store, userId string) error {
+func (si *StoreInteractor) SaveFavoriteStore(store *model.Store, userId int) error {
+	exist, err := si.storeRepository.ExistFavorite(store, userId)
+	if err != nil {
+		return err
+	}
+	if exist {
+		return si.storeOutputPort.OutputAlreadyExistFavorite()
+	}
 	if err := si.storeRepository.SaveFavoriteStore(store, userId); err != nil {
 		return err
 	}

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -1,6 +1,7 @@
 package interactor
 
 import (
+	model "clean-storemap-api/src/entity"
 	port "clean-storemap-api/src/usecase/port"
 )
 
@@ -30,4 +31,8 @@ func (si *StoreInteractor) GetNearStores() error {
 		return err
 	}
 	return si.storeOutputPort.OutputAllStores(places)
+}
+
+func (si *StoreInteractor) SaveFavoriteStore(store *model.Store) error {
+	return nil
 }

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -26,8 +26,8 @@ func (m *MockStoreRepository) GetNearStores() ([]*model.Store, error) {
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepository) SaveFavoriteStore(store *model.Store) error {
-	args := m.Called(store)
+func (m *MockStoreRepository) SaveFavoriteStore(store *model.Store, userId string) error {
+	args := m.Called(store, userId)
 	return args.Error(0)
 }
 
@@ -119,21 +119,21 @@ func TestSaveFavoriteStore(t *testing.T) {
 		PriceLevel:          "PRICE_LEVEL_MODERATE",
 		Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 	}
+	userId := "test@example.com"
 
 	mockStoreRepository := new(MockStoreRepository)
-	mockStoreRepository.On("SaveFavoriteStore", store).Return(nil)
+	mockStoreRepository.On("SaveFavoriteStore", store, userId).Return(nil)
 	mockStoreOutputPort := new(MockStoreOutputPort)
 	mockStoreOutputPort.On("OutputSaveFavoriteStoreResult").Return(nil)
 
 	si := &StoreInteractor{storeRepository: mockStoreRepository, storeOutputPort: mockStoreOutputPort}
 
 	/* Act */
-	actual := si.SaveFavoriteStore(store)
+	actual := si.SaveFavoriteStore(store, userId)
 
 	/* Assert */
 	assert.Equal(t, expected, actual)
 	mockStoreRepository.AssertNumberOfCalls(t, "SaveFavoriteStore", 1)
 	mockStoreOutputPort.AssertNumberOfCalls(t, "OutputSaveFavoriteStoreResult", 1)
-	// RepositoryのSaveFavoriteStoreがstoreを引数として呼ばれること
-	mockStoreRepository.AssertCalled(t, "SaveFavoriteStore", store)
+	mockStoreRepository.AssertCalled(t, "SaveFavoriteStore", store, userId)
 }

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -26,13 +26,18 @@ func (m *MockStoreRepository) GetNearStores() ([]*model.Store, error) {
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepository) SaveFavoriteStore() error {
+func (m *MockStoreRepository) SaveFavoriteStore(*model.Store) error {
 	args := m.Called()
 	return args.Error(0)
 }
 
 func (m *MockStoreOutputPort) OutputAllStores(stores []*model.Store) error {
 	args := m.Called(stores)
+	return args.Error(0)
+}
+
+func (m *MockStoreOutputPort) OutputSaveFavoriteStoreResult() error {
+	args := m.Called()
 	return args.Error(0)
 }
 

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -26,8 +26,8 @@ func (m *MockStoreRepository) GetNearStores() ([]*model.Store, error) {
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepository) SaveFavoriteStore(*model.Store) error {
-	args := m.Called()
+func (m *MockStoreRepository) SaveFavoriteStore(store *model.Store) error {
+	args := m.Called(store)
 	return args.Error(0)
 }
 
@@ -111,7 +111,7 @@ func TestGetNearStores(t *testing.T) {
 
 func TestSaveFavoriteStore(t *testing.T) {
 	/* Arrange */
-	expected := errors.New("")
+	var expected error = nil
 	store := &model.Store{
 		Id:                  "Id001",
 		Name:                "UEC cafe",
@@ -121,8 +121,9 @@ func TestSaveFavoriteStore(t *testing.T) {
 	}
 
 	mockStoreRepository := new(MockStoreRepository)
-	mockStoreRepository.On("SaveFavoriteStore").Return(expected)
+	mockStoreRepository.On("SaveFavoriteStore", store).Return(nil)
 	mockStoreOutputPort := new(MockStoreOutputPort)
+	mockStoreOutputPort.On("OutputSaveFavoriteStoreResult").Return(nil)
 
 	si := &StoreInteractor{storeRepository: mockStoreRepository, storeOutputPort: mockStoreOutputPort}
 
@@ -132,4 +133,7 @@ func TestSaveFavoriteStore(t *testing.T) {
 	/* Assert */
 	assert.Equal(t, expected, actual)
 	mockStoreRepository.AssertNumberOfCalls(t, "SaveFavoriteStore", 1)
+	mockStoreOutputPort.AssertNumberOfCalls(t, "OutputSaveFavoriteStoreResult", 1)
+	// RepositoryのSaveFavoriteStoreがstoreを引数として呼ばれること
+	mockStoreRepository.AssertCalled(t, "SaveFavoriteStore", store)
 }

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -26,6 +26,11 @@ func (m *MockStoreRepository) GetNearStores() ([]*model.Store, error) {
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
+func (m *MockStoreRepository) SaveFavoriteStore() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *MockStoreOutputPort) OutputAllStores(stores []*model.Store) error {
 	args := m.Called(stores)
 	return args.Error(0)
@@ -97,4 +102,29 @@ func TestGetNearStores(t *testing.T) {
 	mockStoreRepository.AssertNumberOfCalls(t, "GetNearStores", 1)
 	mockStoreOutputPort.AssertNumberOfCalls(t, "OutputAllStores", 1)
 	mockStoreOutputPort.AssertCalled(t, "OutputAllStores", stores)
+}
+
+func TestSaveFavoriteStore(t *testing.T) {
+	/* Arrange */
+	expected := errors.New("")
+	store := &model.Store{
+		Id:                  "Id001",
+		Name:                "UEC cafe",
+		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+		PriceLevel:          "PRICE_LEVEL_MODERATE",
+		Location:            model.Location{Lat: "35.713", Lng: "139.762"},
+	}
+
+	mockStoreRepository := new(MockStoreRepository)
+	mockStoreRepository.On("SaveFavoriteStore").Return(expected)
+	mockStoreOutputPort := new(MockStoreOutputPort)
+
+	si := &StoreInteractor{storeRepository: mockStoreRepository, storeOutputPort: mockStoreOutputPort}
+
+	/* Act */
+	actual := si.SaveFavoriteStore(store)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockStoreRepository.AssertNumberOfCalls(t, "SaveFavoriteStore", 1)
 }

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -7,13 +7,13 @@ import (
 type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
-	SaveFavoriteStore(*model.Store) error
+	SaveFavoriteStore(store *model.Store, userId string) error
 }
 
 type StoreRepository interface {
 	GetAll() ([]*model.Store, error)
 	GetNearStores() ([]*model.Store, error)
-	SaveFavoriteStore(*model.Store) error
+	SaveFavoriteStore(store *model.Store, userId string) error
 }
 
 type StoreOutputPort interface {

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -7,7 +7,7 @@ import (
 type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
-	SaveFavoriteStore() error
+	SaveFavoriteStore(*model.Store) error
 }
 
 type StoreRepository interface {

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -13,8 +13,10 @@ type StoreInputPort interface {
 type StoreRepository interface {
 	GetAll() ([]*model.Store, error)
 	GetNearStores() ([]*model.Store, error)
+	SaveFavoriteStore(*model.Store) error
 }
 
 type StoreOutputPort interface {
 	OutputAllStores([]*model.Store) error
+	OutputSaveFavoriteStoreResult() error
 }

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -7,6 +7,7 @@ import (
 type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
+	SaveFavoriteStore() error
 }
 
 type StoreRepository interface {

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -7,16 +7,18 @@ import (
 type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
-	SaveFavoriteStore(store *model.Store, userId string) error
+	SaveFavoriteStore(store *model.Store, userId int) error
 }
 
 type StoreRepository interface {
 	GetAll() ([]*model.Store, error)
 	GetNearStores() ([]*model.Store, error)
-	SaveFavoriteStore(store *model.Store, userId string) error
+	ExistFavorite(store *model.Store, userId int) (bool, error)
+	SaveFavoriteStore(store *model.Store, userId int) error
 }
 
 type StoreOutputPort interface {
 	OutputAllStores([]*model.Store) error
 	OutputSaveFavoriteStoreResult() error
+	OutputAlreadyExistFavorite() error
 }


### PR DESCRIPTION
## 本PRでやったこと
- `POST /stores/favorite`の作成
- 各レイヤーのテスト実装

## 実行例
- 画面上部はpostmanで叩く様子、下部はdbに保存された様子です。
- request bodyの例は/exampleにて`post_stores_favorite.json`という名前で追加しています。
<img width="1175" alt="Screenshot 2024-11-21 at 18 39 04" src="https://github.com/user-attachments/assets/11b344af-9e17-4616-b538-e037b1cf8e12">

- 一度dbに保存されていると、下記のようにエラーが返されます。
<img width="835" alt="Screenshot 2024-11-21 at 18 35 23" src="https://github.com/user-attachments/assets/79b2ab84-ae41-48f1-a7bd-6d296bc65896">

- 存在しないuserIdを指定すると、foreignKeyで弾かれてinternal server errorになります。
![Screenshot 2024-11-21 at 18 36 28](https://github.com/user-attachments/assets/83b1bedd-f555-4f88-907a-49c00a763cb7)

## Todo
- userIdをプリミティブなintからUserIdにしたかったのですが、user関連で変更しなくてはならない部分が多すぎました。。。
- mainが綺麗になった後にuserIdをuuidに変更したいです！

## Next
- お気に入り件数ランキングページのためのGETメソッド実装
- 余裕があればお気に入りを取り消す機能をつけたい