### PR TITLE
[back/feat] 直近1週間のお気に入りランキングtop10位のお店を返す

### DIFF
--- a/example/post_stores_favorite.json
+++ b/example/post_stores_favorite.json
@@ -1,0 +1,9 @@
+{
+    "userId": 1,
+    "storeId": "Id002",
+    "storeName": "UEC cafe",
+    "regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+    "priceLevel": "PRICE_LEVEL_MODERATE",
+    "latitude": "35.713",
+    "longitude": "139.762"
+}

--- a/example/post_stores_favorite.json
+++ b/example/post_stores_favorite.json
@@ -1,5 +1,4 @@
 {
-    "userId": 1,
     "storeId": "Id002",
     "storeName": "UEC cafe",
     "regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",

--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -24,6 +24,7 @@ type StoreI interface {
 	GetStores(c echo.Context) error
 	GetNearStores(c echo.Context) error
 	SaveFavoriteStore(c echo.Context) error
+	GetTopFavoriteStores(c echo.Context) error
 }
 
 type StoreOutputFactory func(echo.Context) port.StoreOutputPort
@@ -77,6 +78,10 @@ func (sc *StoreController) SaveFavoriteStore(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
 	return sc.newStoreInputPort(c).SaveFavoriteStore(store, s.UserId)
+}
+
+func (sc *StoreController) GetTopFavoriteStores(c echo.Context) error {
+	return sc.newStoreInputPort(c).GetTopFavoriteStores()
 }
 
 /* ここでpresenterにecho.Contextを渡している！起爆！！！（遅延） */

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -54,6 +54,11 @@ func (m *MockStoreDriverFactory) SaveStore(*db.FavoriteStore) error {
 	return args.Error(0)
 }
 
+func (m *MockStoreDriverFactory) GetTopStores() ([]*db.FavoriteStore, error) {
+	args := m.Called()
+	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
+}
+
 func (m *MockGoogleMapDriverFactory) GetStores() ([]*api.Store, error) {
 	args := m.Called()
 	return args.Get(0).([]*api.Store), args.Error(1)
@@ -98,6 +103,11 @@ func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(store *model.St
 	return args.Error(0)
 }
 
+func (m *MockStoreRepositoryFactoryFuncObject) GetTopFavoriteStores() ([]*model.Store, error) {
+	args := m.Called()
+	return args.Get(0).([]*model.Store), args.Error(1)
+}
+
 func mockStoreRepositoryFactoryFunc(storeDriver gateway.StoreDriver, googleMapDriver gateway.GoogleMapDriver) port.StoreRepository {
 	return &MockStoreRepositoryFactoryFuncObject{}
 }
@@ -113,6 +123,11 @@ func (m *MockStoreInputFactoryFuncObject) GetNearStores() error {
 }
 
 func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId int) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStoreInputFactoryFuncObject) GetTopFavoriteStores() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -245,4 +260,33 @@ func TestFavoriteSaveStore(t *testing.T) {
 	assert.Equal(t, expected, actual)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	mockStoreInputFactoryFuncObject.AssertNumberOfCalls(t, "SaveFavoriteStore", 1)
+}
+
+func TestGetTopFavoriteStores(t *testing.T) {
+	/* Arrange */
+	var expected error = nil
+	c, rec := newRouter()
+
+	mockStoreDriverFactory := new(MockStoreDriverFactory)
+	mockStoreDriverFactory.On("GetTopStores").Return([]*db.FavoriteStore{}, nil)
+
+	sc := &StoreController{
+		storeDriverFactory:     mockStoreDriverFactory,
+		storeOutputFactory:     mockStoreOutputFactoryFunc,
+		storeRepositoryFactory: mockStoreRepositoryFactoryFunc,
+	}
+
+	mockStoreInputFactoryFuncObject := new(MockStoreInputFactoryFuncObject)
+	mockStoreInputFactoryFuncObject.On("GetTopFavoriteStores").Return(nil)
+	sc.storeInputFactory = func(repository port.StoreRepository, output port.StoreOutputPort) port.StoreInputPort {
+		return mockStoreInputFactoryFuncObject
+	}
+
+	/* Act */
+	actual := sc.GetTopFavoriteStores(c)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	mockStoreInputFactoryFuncObject.AssertNumberOfCalls(t, "GetTopFavoriteStores", 1)
 }

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -21,6 +21,7 @@ type StoreDriver interface {
 	GetStores() ([]*db.FavoriteStore, error)
 	FindFavorite(storeId string, userId int) (*db.FavoriteStore, error)
 	SaveStore(*db.FavoriteStore) error
+	GetTopStores() ([]*db.FavoriteStore, error)
 }
 
 type GoogleMapDriver interface {
@@ -102,6 +103,28 @@ func (sg *StoreGateway) SaveFavoriteStore(store *model.Store, userId int) error 
 	}
 
 	return nil
+}
+
+func (sg *StoreGateway) GetTopFavoriteStores() ([]*model.Store, error) {
+	dbStores, err := sg.storeDriver.GetTopStores()
+	if err != nil {
+		return nil, err
+	}
+	stores := make([]*model.Store, 0)
+	for _, v := range dbStores {
+		stores = append(stores, &model.Store{
+			Id:                  v.StoreId,
+			Name:                v.StoreName,
+			RegularOpeningHours: v.RegularOpeningHours,
+			PriceLevel:          v.PriceLevel,
+			Location: model.Location{
+				Lat: v.Latitude,
+				Lng: v.Longitude,
+			},
+		})
+	}
+
+	return stores, nil
 }
 
 // DoesDuplicateFavorite()

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -126,6 +126,3 @@ func (sg *StoreGateway) GetTopFavoriteStores() ([]*model.Store, error) {
 
 	return stores, nil
 }
-
-// DoesDuplicateFavorite()
-// -> storeId && userIdが favorite store tableに存在するかどうかを確認する

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -78,8 +78,11 @@ func (sg *StoreGateway) GetNearStores() ([]*model.Store, error) {
 }
 
 func (sg *StoreGateway) ExistFavorite(store *model.Store, userId int) (bool, error) {
-	_, err := sg.storeDriver.FindFavorite(store.Id, userId)
+	dbStore, err := sg.storeDriver.FindFavorite(store.Id, userId)
 	if err != nil {
+		return false, err
+	}
+	if dbStore == nil {
 		return false, nil
 	}
 	return true, nil

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -13,6 +13,8 @@ import (
 func makeDummyDbStores() ([]*db.FavoriteStore, error) {
 	dummyStores := make([]*db.FavoriteStore, 0)
 	dummyStores = append(dummyStores, &db.FavoriteStore{
+		Id:                  "id_1",
+		UserId:              1,
 		StoreId:             "Id001",
 		StoreName:           "UEC cafe",
 		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
@@ -21,6 +23,8 @@ func makeDummyDbStores() ([]*db.FavoriteStore, error) {
 		Longitude:           "139.762",
 	})
 	dummyStores = append(dummyStores, &db.FavoriteStore{
+		Id:                  "id_2",
+		UserId:              1,
 		StoreId:             "Id002",
 		StoreName:           "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
@@ -29,6 +33,8 @@ func makeDummyDbStores() ([]*db.FavoriteStore, error) {
 		Longitude:           "139.763",
 	})
 	dummyStores = append(dummyStores, &db.FavoriteStore{
+		Id:                  "id_2",
+		UserId:              2,
 		StoreId:             "Id002",
 		StoreName:           "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
@@ -100,7 +106,7 @@ func TestGetAll(t *testing.T) {
 	stores = append(
 		stores,
 		&model.Store{
-			Id:                  "Id001",
+			Id:                  "id_1",
 			Name:                "UEC cafe",
 			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 			PriceLevel:          "PRICE_LEVEL_MODERATE",
@@ -110,7 +116,7 @@ func TestGetAll(t *testing.T) {
 	stores = append(
 		stores,
 		&model.Store{
-			Id:                  "Id002",
+			Id:                  "id_2",
 			Name:                "UEC restaurant",
 			RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
 			PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
@@ -120,7 +126,7 @@ func TestGetAll(t *testing.T) {
 	stores = append(
 		stores,
 		&model.Store{
-			Id:                  "Id002",
+			Id:                  "id_2",
 			Name:                "UEC restaurant",
 			RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
 			PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -13,7 +13,7 @@ import (
 func makeDummyDbStores() ([]*db.FavoriteStore, error) {
 	dummyStores := make([]*db.FavoriteStore, 0)
 	dummyStores = append(dummyStores, &db.FavoriteStore{
-		Id:                  "Id001",
+		StoreId:             "Id001",
 		StoreName:           "UEC cafe",
 		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 		PriceLevel:          "PRICE_LEVEL_MODERATE",
@@ -21,7 +21,15 @@ func makeDummyDbStores() ([]*db.FavoriteStore, error) {
 		Longitude:           "139.762",
 	})
 	dummyStores = append(dummyStores, &db.FavoriteStore{
-		Id:                  "Id002",
+		StoreId:             "Id002",
+		StoreName:           "UEC restaurant",
+		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
+		PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
+		Latitude:            "35.714",
+		Longitude:           "139.763",
+	})
+	dummyStores = append(dummyStores, &db.FavoriteStore{
+		StoreId:             "Id002",
 		StoreName:           "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
 		PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
@@ -69,6 +77,11 @@ func (m *MockStoreRepository) SaveStore(dbStore *db.FavoriteStore) error {
 	return args.Error(0)
 }
 
+func (m *MockStoreRepository) GetTopStores() ([]*db.FavoriteStore, error) {
+	args := m.Called()
+	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
+}
+
 type MockGoogleMapRepository struct {
 	mock.Mock
 }
@@ -92,6 +105,16 @@ func TestGetAll(t *testing.T) {
 			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
 			PriceLevel:          "PRICE_LEVEL_MODERATE",
 			Location:            model.Location{Lat: "35.713", Lng: "139.762"},
+		},
+	)
+	stores = append(
+		stores,
+		&model.Store{
+			Id:                  "Id002",
+			Name:                "UEC restaurant",
+			RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
+			PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
+			Location:            model.Location{Lat: "35.714", Lng: "139.763"},
 		},
 	)
 	stores = append(
@@ -180,4 +203,50 @@ func TestSaveFavoriteStore(t *testing.T) {
 	/* Assert */
 	assert.Equal(t, expected, actual)
 	mockStoreRepository.AssertNumberOfCalls(t, "SaveStore", 1)
+}
+
+func TestGetTopFavoriteStores(t *testing.T) {
+	/* Arrange */
+	mockStoreRepository := new(MockStoreRepository)
+	mockStoreRepository.On("GetTopStores").Return(makeDummyDbStores())
+	sg := &StoreGateway{storeDriver: mockStoreRepository}
+	stores := make([]*model.Store, 0)
+	stores = append(
+		stores,
+		&model.Store{
+			Id:                  "Id001",
+			Name:                "UEC cafe",
+			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+			PriceLevel:          "PRICE_LEVEL_MODERATE",
+			Location:            model.Location{Lat: "35.713", Lng: "139.762"},
+		},
+	)
+	stores = append(
+		stores,
+		&model.Store{
+			Id:                  "Id002",
+			Name:                "UEC restaurant",
+			RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
+			PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
+			Location:            model.Location{Lat: "35.714", Lng: "139.763"},
+		},
+	)
+	stores = append(
+		stores,
+		&model.Store{
+			Id:                  "Id002",
+			Name:                "UEC restaurant",
+			RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
+			PriceLevel:          "PRICE_LEVEL_INEXPENSIVE",
+			Location:            model.Location{Lat: "35.714", Lng: "139.763"},
+		},
+	)
+	expected := stores
+
+	/* Act */
+	actual, _ := sg.GetTopFavoriteStores()
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockStoreRepository.AssertNumberOfCalls(t, "GetTopStores", 1)
 }

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -1,7 +1,10 @@
 package db
 
 import (
+	"errors"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type DbStoreDriver struct{}
@@ -38,6 +41,9 @@ func (dbs *DbStoreDriver) FindFavorite(storeId string, userId int) (*FavoriteSto
 	var store FavoriteStore
 	err := DB.Where("store_id = ? AND user_id = ?", storeId, userId).First(&store).Error
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return &store, nil

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -43,6 +43,7 @@ func (router *Router) Serve(ctx context.Context) {
 	router.echo.GET("/", router.storeController.GetStores)
 	router.echo.GET("/stores/opening-hours", router.storeController.GetNearStores)
 	router.echo.POST("/stores/favorite", router.storeController.SaveFavoriteStore)
+	router.echo.GET("/stores/favorite-ranking", router.storeController.GetTopFavoriteStores)
 	router.echo.POST("/user", router.userController.CreateUser) // こっちは時期に使わなくなります。
 	router.echo.POST("/login", router.userController.LoginUser)
 	router.echo.GET("/auth", router.userController.GetAuthUrl)            // Google認証用のURLを取得し返す

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -49,3 +49,11 @@ func (si *StoreInteractor) SaveFavoriteStore(store *model.Store, userId int) err
 	}
 	return nil
 }
+
+func (si *StoreInteractor) GetTopFavoriteStores() error {
+	stores, err := si.storeRepository.GetTopFavoriteStores()
+	if err != nil {
+		return err
+	}
+	return si.storeOutputPort.OutputAllStores(stores)
+}

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -8,6 +8,7 @@ type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
 	SaveFavoriteStore(store *model.Store, userId int) error
+	GetTopFavoriteStores() error
 }
 
 type StoreRepository interface {
@@ -15,6 +16,7 @@ type StoreRepository interface {
 	GetNearStores() ([]*model.Store, error)
 	ExistFavorite(store *model.Store, userId int) (bool, error)
 	SaveFavoriteStore(store *model.Store, userId int) error
+	GetTopFavoriteStores() ([]*model.Store, error)
 }
 
 type StoreOutputPort interface {


### PR DESCRIPTION
## お願い
- #29 の実装に依存しているため、先にこちらをレビューしていただけると嬉しいです🙇‍♂️

## 本PRでやったこと
- `GET /stores/favorite-ranking`の実装
- 各レイヤーのテストの実装

## 仕様
- 直近1週間・お気に入り登録数が多い順・10件という条件でお店を検索し、json形式で返します
- ランキング一覧ページで叩かれることを想定しています。

## 実行例
- 2店舗に対して、計3件のお気に入り登録がある場合
<img width="748" alt="Screenshot 2024-11-21 at 21 15 02" src="https://github.com/user-attachments/assets/ea297602-0d56-46ae-8b72-a55b2bc5d058">

- 登録数の多いId002から順に返す
<img width="1189" alt="Screenshot 2024-11-21 at 21 04 11" src="https://github.com/user-attachments/assets/dadd7580-98f6-4520-bbf5-ae06ac920a03">
