### PR TITLE
get-favorite-store: ユーザの持つお気に入り店舗一覧を取得

### DIFF
--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -23,6 +23,7 @@ type StoreRequestBody struct {
 type StoreI interface {
 	GetStores(c echo.Context) error
 	GetNearStores(c echo.Context) error
+	GetFavoriteStores(c echo.Context) error
 	SaveFavoriteStore(c echo.Context) error
 	GetTopFavoriteStores(c echo.Context) error
 }
@@ -63,6 +64,18 @@ func (sc *StoreController) GetStores(c echo.Context) error {
 
 func (sc *StoreController) GetNearStores(c echo.Context) error {
 	return sc.newStoreInputPort(c).GetNearStores()
+}
+
+func (sc *StoreController) GetFavoriteStores(c echo.Context) error {
+	userIdParam := c.Param("user_id")
+	if userIdParam == "" {
+		return c.JSON(http.StatusBadRequest, "user_id is required")
+	}
+	userId, err := strconv.Atoi(userIdParam)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, "user_id must be a valid integer")
+	}
+	return sc.newStoreInputPort(c).GetFavoriteStores(userId)
 }
 
 func (sc *StoreController) SaveFavoriteStore(c echo.Context) error {

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -20,6 +20,7 @@ type StoreGateway struct {
 type StoreDriver interface {
 	GetStores() ([]*db.FavoriteStore, error)
 	FindFavorite(storeId string, userId int) (*db.FavoriteStore, error)
+	FindFavoriteByUser(userId int) ([]*db.FavoriteStore, error)
 	SaveStore(*db.FavoriteStore) error
 	GetTopStores() ([]*db.FavoriteStore, error)
 }
@@ -86,6 +87,27 @@ func (sg *StoreGateway) ExistFavorite(store *model.Store, userId int) (bool, err
 		return false, nil
 	}
 	return true, nil
+}
+
+func (sg *StoreGateway) GetFavoriteStores(userId int) ([]*model.Store, error) {
+	dbStores, err := sg.storeDriver.FindFavoriteByUser(userId)
+	if err != nil {
+		return nil, err
+	}
+	stores := make([]*model.Store, 0)
+	for _, v := range dbStores {
+		stores = append(stores, &model.Store{
+			Id:                  v.StoreId,
+			Name:                v.StoreName,
+			RegularOpeningHours: v.RegularOpeningHours,
+			PriceLevel:          v.PriceLevel,
+			Location: model.Location{
+				Lat: v.Latitude,
+				Lng: v.Longitude,
+			},
+		})
+	}
+	return stores, nil
 }
 
 func (sg *StoreGateway) SaveFavoriteStore(store *model.Store, userId int) error {

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -53,6 +53,15 @@ func (dbs *DbStoreDriver) FindFavorite(storeId string, userId int) (*FavoriteSto
 	return &stores[0], nil
 }
 
+func (dbs *DbStoreDriver) FindFavoriteByUser(userId int) ([]*FavoriteStore, error) {
+	var stores []*FavoriteStore
+	err := DB.Where("user_id = ?", userId).Find(&stores).Error
+	if err != nil {
+		return nil, err
+	}
+	return stores, nil
+}
+
 func (dbs *DbStoreDriver) SaveStore(dbStore *FavoriteStore) error {
 	err := DB.Create(&dbStore).Error
 	if err != nil {

--- a/src/driver/router/router.go
+++ b/src/driver/router/router.go
@@ -43,6 +43,7 @@ func (router *Router) Serve(ctx context.Context) {
 	router.echo.GET("/", router.storeController.GetStores)
 	router.echo.GET("/stores/opening-hours", router.storeController.GetNearStores)
 	router.echo.GET("/stores/favorite-ranking", router.storeController.GetTopFavoriteStores)
+	router.echo.GET("/user/:user_id/favorite-store", router.storeController.GetFavoriteStores)
 	router.echo.POST("/user/:user_id/favorite-store", router.storeController.SaveFavoriteStore)
 	router.echo.POST("/user", router.userController.CreateUser) // こっちは時期に使わなくなります。
 	router.echo.POST("/login", router.userController.LoginUser)

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -33,6 +33,14 @@ func (si *StoreInteractor) GetNearStores() error {
 	return si.storeOutputPort.OutputAllStores(places)
 }
 
+func (si *StoreInteractor) GetFavoriteStores(userId int) error {
+	stores, err := si.storeRepository.GetFavoriteStores(userId)
+	if err != nil {
+		return err
+	}
+	return si.storeOutputPort.OutputAllStores(stores)
+}
+
 func (si *StoreInteractor) SaveFavoriteStore(store *model.Store, userId int) error {
 	exist, err := si.storeRepository.ExistFavorite(store, userId)
 	if err != nil {

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -31,6 +31,11 @@ func (m *MockStoreRepository) ExistFavorite(store *model.Store, userId int) (boo
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockStoreRepository) GetFavoriteStores(userId int) ([]*model.Store, error) {
+	args := m.Called(userId)
+	return args.Get(0).([]*model.Store), args.Error(1)
+}
+
 func (m *MockStoreRepository) SaveFavoriteStore(store *model.Store, userId int) error {
 	args := m.Called(store, userId)
 	return args.Error(0)
@@ -120,6 +125,39 @@ func TestGetNearStores(t *testing.T) {
 	/* Assert */
 	assert.Equal(t, expected, actual)
 	mockStoreRepository.AssertNumberOfCalls(t, "GetNearStores", 1)
+	mockStoreOutputPort.AssertNumberOfCalls(t, "OutputAllStores", 1)
+	mockStoreOutputPort.AssertCalled(t, "OutputAllStores", stores)
+}
+
+func TestGetFavoriteStores(t *testing.T) {
+	/* Arrange */
+	expected := errors.New("")
+	stores := make([]*model.Store, 0)
+	stores = append(
+		stores,
+		&model.Store{
+			Id:                  "Id001",
+			Name:                "UEC cafe",
+			RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
+			PriceLevel:          "PRICE_LEVEL_MODERATE",
+			Location:            model.Location{Lat: "35.713", Lng: "139.762"},
+		},
+	)
+	userId := 1
+
+	mockStoreRepository := new(MockStoreRepository)
+	mockStoreRepository.On("GetFavoriteStores", userId).Return(stores, nil)
+	mockStoreOutputPort := new(MockStoreOutputPort)
+	mockStoreOutputPort.On("OutputAllStores", stores).Return(expected)
+
+	si := &StoreInteractor{storeRepository: mockStoreRepository, storeOutputPort: mockStoreOutputPort}
+
+	/* Act */
+	actual := si.GetFavoriteStores(userId)
+
+	/* Assert */
+	assert.Equal(t, expected, actual)
+	mockStoreRepository.AssertNumberOfCalls(t, "GetFavoriteStores", 1)
 	mockStoreOutputPort.AssertNumberOfCalls(t, "OutputAllStores", 1)
 	mockStoreOutputPort.AssertCalled(t, "OutputAllStores", stores)
 }

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -7,6 +7,7 @@ import (
 type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
+	GetFavoriteStores(userId int) error
 	SaveFavoriteStore(store *model.Store, userId int) error
 	GetTopFavoriteStores() error
 }
@@ -15,6 +16,7 @@ type StoreRepository interface {
 	GetAll() ([]*model.Store, error)
 	GetNearStores() ([]*model.Store, error)
 	ExistFavorite(store *model.Store, userId int) (bool, error)
+	GetFavoriteStores(userId int) ([]*model.Store, error)
 	SaveFavoriteStore(store *model.Store, userId int) error
 	GetTopFavoriteStores() ([]*model.Store, error)
 }


### PR DESCRIPTION
### 機能

ユーザの持つお気に入り店舗一覧を取得する

### 使い方

リクエスト
`curl http://localhost:8080/user/:user_id/favorite-store | jq .`

レスポンス例
```
{
  "stores": [
    {
      "id": "Id003",
      "name": "UEC restaurant",
      "regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
      "priceLevel": "PRICE_LEVEL_MODERATE",
      "location": {
        "latitude": "35.713",
        "longitude": "139.762"
      }
    },
    {
      "id": "Id002",
      "name": "UEC cafe",
      "regularOpeningHours": "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
      "priceLevel": "PRICE_LEVEL_MODERATE",
      "location": {
        "latitude": "35.713",
        "longitude": "139.762"
      }
    }
  ]
}
```
