### PR TITLE
userのIDでuuidを使用

### DIFF
--- a/src/adapter/controller/store.go
+++ b/src/adapter/controller/store.go
@@ -5,7 +5,6 @@ import (
 	model "clean-storemap-api/src/entity"
 	"clean-storemap-api/src/usecase/port"
 	"net/http"
-	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"gopkg.in/go-playground/validator.v9"
@@ -67,26 +66,18 @@ func (sc *StoreController) GetNearStores(c echo.Context) error {
 }
 
 func (sc *StoreController) GetFavoriteStores(c echo.Context) error {
-	userIdParam := c.Param("user_id")
-	if userIdParam == "" {
+	userId := c.Param("user_id")
+	if userId == "" {
 		return c.JSON(http.StatusBadRequest, "user_id is required")
-	}
-	userId, err := strconv.Atoi(userIdParam)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, "user_id must be a valid integer")
 	}
 	return sc.newStoreInputPort(c).GetFavoriteStores(userId)
 }
 
 func (sc *StoreController) SaveFavoriteStore(c echo.Context) error {
 	var s StoreRequestBody
-	userIdParam := c.Param("user_id")
-	if userIdParam == "" {
+	userId := c.Param("user_id")
+	if userId == "" {
 		return c.JSON(http.StatusBadRequest, "user_id is required")
-	}
-	userId, err := strconv.Atoi(userIdParam)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, "user_id must be a valid integer")
 	}
 
 	if err := c.Bind(&s); err != nil {

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -242,7 +242,7 @@ func TestGetFavoriteStores(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c.SetRequest(req)
 	c.SetParamNames("user_id")
-	c.SetParamValues("1")
+	c.SetParamValues("id_1")
 
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("FindStores").Return(&db.FavoriteStore{}, nil)
@@ -286,7 +286,7 @@ func TestFavoriteSaveStore(t *testing.T) {
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c.SetRequest(req)
 	c.SetParamNames("user_id")
-	c.SetParamValues("1")
+	c.SetParamValues("id_1")
 
 	mockStoreDriverFactory := new(MockStoreDriverFactory)
 	mockStoreDriverFactory.On("GetStores").Return([]*db.FavoriteStore{}, nil)

--- a/src/adapter/controller/store_test.go
+++ b/src/adapter/controller/store_test.go
@@ -44,12 +44,12 @@ func (m *MockStoreDriverFactory) GetStores() ([]*db.FavoriteStore, error) {
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
-func (m *MockStoreDriverFactory) FindFavorite(string, int) (*db.FavoriteStore, error) {
+func (m *MockStoreDriverFactory) FindFavorite(string, string) (*db.FavoriteStore, error) {
 	args := m.Called()
 	return args.Get(0).(*db.FavoriteStore), args.Error(1)
 }
 
-func (m *MockStoreDriverFactory) FindFavoriteByUser(int) ([]*db.FavoriteStore, error) {
+func (m *MockStoreDriverFactory) FindFavoriteByUser(string) ([]*db.FavoriteStore, error) {
 	args := m.Called()
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
@@ -98,17 +98,17 @@ func (m *MockStoreRepositoryFactoryFuncObject) GetNearStores() ([]*model.Store, 
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepositoryFactoryFuncObject) ExistFavorite(store *model.Store, userId int) (bool, error) {
+func (m *MockStoreRepositoryFactoryFuncObject) ExistFavorite(store *model.Store, userId string) (bool, error) {
 	args := m.Called(store, userId)
 	return args.Get(0).(bool), args.Error(1)
 }
 
-func (m *MockStoreRepositoryFactoryFuncObject) GetFavoriteStores(userId int) ([]*model.Store, error) {
+func (m *MockStoreRepositoryFactoryFuncObject) GetFavoriteStores(userId string) ([]*model.Store, error) {
 	args := m.Called()
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId int) error {
+func (m *MockStoreRepositoryFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId string) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -132,12 +132,12 @@ func (m *MockStoreInputFactoryFuncObject) GetNearStores() error {
 	return args.Error(0)
 }
 
-func (m *MockStoreInputFactoryFuncObject) GetFavoriteStores(userId int) error {
+func (m *MockStoreInputFactoryFuncObject) GetFavoriteStores(userId string) error {
 	args := m.Called()
 	return args.Error(0)
 }
 
-func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId int) error {
+func (m *MockStoreInputFactoryFuncObject) SaveFavoriteStore(store *model.Store, userId string) error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/src/adapter/controller/user.go
+++ b/src/adapter/controller/user.go
@@ -82,7 +82,7 @@ func (uc *UserController) CreateUser(c echo.Context) error {
 }
 
 func (uc *UserController) UpdateUser(c echo.Context) error {
-	idStr := c.Param("id")
+	id := c.Param("id")
 	// UserRequestBodyを使用すると存在しないkeyに関しても値が生成されてしまうため、UserRequestBodyにバインドさせずに取得する
 	var requestBody map[string]interface{}
 	// 数字 -> float64, 文字列-> stringと変換される
@@ -92,12 +92,6 @@ func (uc *UserController) UpdateUser(c echo.Context) error {
 
 	updateData := make(model.ChangeForUser)
 	// 更新データを型変換しつつ格納する
-	// id
-	var id int
-	var err error
-	if id, err = strconv.Atoi(idStr); err != nil {
-		return c.JSON(http.StatusInternalServerError, "id is not int")
-	}
 
 	// name
 	if name, ok := requestBody["name"]; ok {

--- a/src/adapter/controller/user.go
+++ b/src/adapter/controller/user.go
@@ -39,7 +39,6 @@ type UserController struct {
 // 数字型のものが未入力であれば0として扱われる
 // 0を存在する値とする場合にはカスタムバリデーションを使用する必要があり、カスタムバリデーションにはrouterで定義されたecho.New()を使用するため今回はカスタムバリデーションを使用しない。
 type UserRequestBody struct {
-	Id     int     `json:"id"`
 	Name   string  `json:"name" validate:"required"`
 	Email  string  `json:"email" validate:"required,email"`
 	Age    int     `json:"age"`

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -44,7 +44,7 @@ func (m *MockUserDriverFactory) UpdateUser(*db.User, map[string]interface{}) err
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockUserDriverFactory) FindById(int) (*db.User, error) {
+func (m *MockUserDriverFactory) FindById(string) (*db.User, error) {
 	args := m.Called()
 	return args.Get(0).(*db.User), args.Error(1)
 }
@@ -78,12 +78,12 @@ func (m *MockUserOutputFactoryFuncObject) OutputAuthUrl(url string) error {
 	return args.Error(0)
 }
 
-func (m *MockUserOutputFactoryFuncObject) OutputLoginResult(int) error {
+func (m *MockUserOutputFactoryFuncObject) OutputLoginResult(string) error {
 	args := m.Called()
 	return args.Error(0)
 }
 
-func (m *MockUserOutputFactoryFuncObject) OutputSignupWithAuth(int) error {
+func (m *MockUserOutputFactoryFuncObject) OutputSignupWithAuth(string) error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -117,7 +117,7 @@ func (m *MockUserRepositoryFactoryFuncObject) Update(*model.User, model.ChangeFo
 	return args.Error(0)
 }
 
-func (m *MockUserRepositoryFactoryFuncObject) Get(int) (*model.User, error) {
+func (m *MockUserRepositoryFactoryFuncObject) Get(string) (*model.User, error) {
 	args := m.Called()
 	return args.Get(0).(*model.User), args.Error(1)
 }
@@ -145,7 +145,7 @@ func (m *MockUserInputFactoryFuncObject) CreateUser(*model.User) error {
 	args := m.Called()
 	return args.Error(0)
 }
-func (m *MockUserInputFactoryFuncObject) UpdateUser(int, model.ChangeForUser) error {
+func (m *MockUserInputFactoryFuncObject) UpdateUser(string, model.ChangeForUser) error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/src/adapter/controller/user_test.go
+++ b/src/adapter/controller/user_test.go
@@ -210,12 +210,12 @@ func TestUpdateUser(t *testing.T) {
 	c, rec := newRouter()
 	var expected error = nil
 	reqBody := `{"name":"test","age":10,"sex":0.4, "gender":0}`
-	req := httptest.NewRequest(http.MethodPut, "/user/1", bytes.NewBufferString(reqBody))
+	req := httptest.NewRequest(http.MethodPut, "/user/:id", bytes.NewBufferString(reqBody))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c.SetRequest(req)
 	// パスパラメータを設定
 	c.SetParamNames("id")
-	c.SetParamValues("1")
+	c.SetParamValues("id_1")
 
 	// Driver用
 	mockUserDriverFactory := new(MockUserDriverFactory)

--- a/src/adapter/gateway/store.go
+++ b/src/adapter/gateway/store.go
@@ -19,8 +19,8 @@ type StoreGateway struct {
 
 type StoreDriver interface {
 	GetStores() ([]*db.FavoriteStore, error)
-	FindFavorite(storeId string, userId int) (*db.FavoriteStore, error)
-	FindFavoriteByUser(userId int) ([]*db.FavoriteStore, error)
+	FindFavorite(storeId string, userId string) (*db.FavoriteStore, error)
+	FindFavoriteByUser(userId string) ([]*db.FavoriteStore, error)
 	SaveStore(*db.FavoriteStore) error
 	GetTopStores() ([]*db.FavoriteStore, error)
 }
@@ -78,7 +78,7 @@ func (sg *StoreGateway) GetNearStores() ([]*model.Store, error) {
 	return stores, nil
 }
 
-func (sg *StoreGateway) ExistFavorite(store *model.Store, userId int) (bool, error) {
+func (sg *StoreGateway) ExistFavorite(store *model.Store, userId string) (bool, error) {
 	dbStore, err := sg.storeDriver.FindFavorite(store.Id, userId)
 	if err != nil {
 		return false, err
@@ -89,7 +89,7 @@ func (sg *StoreGateway) ExistFavorite(store *model.Store, userId int) (bool, err
 	return true, nil
 }
 
-func (sg *StoreGateway) GetFavoriteStores(userId int) ([]*model.Store, error) {
+func (sg *StoreGateway) GetFavoriteStores(userId string) ([]*model.Store, error) {
 	dbStores, err := sg.storeDriver.FindFavoriteByUser(userId)
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func (sg *StoreGateway) GetFavoriteStores(userId int) ([]*model.Store, error) {
 	return stores, nil
 }
 
-func (sg *StoreGateway) SaveFavoriteStore(store *model.Store, userId int) error {
+func (sg *StoreGateway) SaveFavoriteStore(store *model.Store, userId string) error {
 	dbStore := &db.FavoriteStore{
 		Id:                  uuid.New().String(),
 		UserId:              userId,

--- a/src/adapter/gateway/store_test.go
+++ b/src/adapter/gateway/store_test.go
@@ -14,7 +14,7 @@ func makeDummyDbStores() ([]*db.FavoriteStore, error) {
 	dummyStores := make([]*db.FavoriteStore, 0)
 	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "id_1",
-		UserId:              1,
+		UserId:              "Id001",
 		StoreId:             "Id001",
 		StoreName:           "UEC cafe",
 		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
@@ -24,7 +24,7 @@ func makeDummyDbStores() ([]*db.FavoriteStore, error) {
 	})
 	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "id_2",
-		UserId:              1,
+		UserId:              "Id001",
 		StoreId:             "Id002",
 		StoreName:           "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
@@ -34,7 +34,7 @@ func makeDummyDbStores() ([]*db.FavoriteStore, error) {
 	})
 	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "id_2",
-		UserId:              2,
+		UserId:              "Id002",
 		StoreId:             "Id002",
 		StoreName:           "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
@@ -49,7 +49,7 @@ func makeDummyDbStoresByUser() ([]*db.FavoriteStore, error) {
 	dummyStores := make([]*db.FavoriteStore, 0)
 	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "id_1",
-		UserId:              1,
+		UserId:              "Id001",
 		StoreId:             "Id001",
 		StoreName:           "UEC cafe",
 		RegularOpeningHours: "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00",
@@ -59,7 +59,7 @@ func makeDummyDbStoresByUser() ([]*db.FavoriteStore, error) {
 	})
 	dummyStores = append(dummyStores, &db.FavoriteStore{
 		Id:                  "id_2",
-		UserId:              1,
+		UserId:              "Id001",
 		StoreId:             "Id002",
 		StoreName:           "UEC restaurant",
 		RegularOpeningHours: "Sat: 11:00 - 20:00, Sun: 11:00 - 20:00",
@@ -98,12 +98,12 @@ func (m *MockStoreRepository) GetStores() ([]*db.FavoriteStore, error) {
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
 
-func (m *MockStoreRepository) FindFavorite(storeId string, userId int) (*db.FavoriteStore, error) {
+func (m *MockStoreRepository) FindFavorite(storeId string, userId string) (*db.FavoriteStore, error) {
 	args := m.Called(storeId, userId)
 	return args.Get(0).(*db.FavoriteStore), args.Error(1)
 }
 
-func (m *MockStoreRepository) FindFavoriteByUser(userId int) ([]*db.FavoriteStore, error) {
+func (m *MockStoreRepository) FindFavoriteByUser(userId string) ([]*db.FavoriteStore, error) {
 	args := m.Called(userId)
 	return args.Get(0).([]*db.FavoriteStore), args.Error(1)
 }
@@ -210,7 +210,7 @@ func TestGetNearStores(t *testing.T) {
 
 func TestGetFavoriteStores(t *testing.T) {
 	/* Arrange */
-	userId := 1
+	userId := "Id001"
 	mockStoreRepository := new(MockStoreRepository)
 	mockStoreRepository.On("FindFavoriteByUser", userId).Return(makeDummyDbStoresByUser())
 	sg := &StoreGateway{storeDriver: mockStoreRepository}
@@ -242,7 +242,7 @@ func TestGetFavoriteStores(t *testing.T) {
 
 	/* Assert */
 	assert.Equal(t, expected, actual)
-	mockStoreRepository.AssertNumberOfCalls(t, "FindFavoriteByUser", userId)
+	mockStoreRepository.AssertNumberOfCalls(t, "FindFavoriteByUser", 1)
 }
 
 func TestSaveFavoriteStore(t *testing.T) {
@@ -251,7 +251,7 @@ func TestSaveFavoriteStore(t *testing.T) {
 	mockStoreRepository := new(MockStoreRepository)
 	mockStoreRepository.On("SaveStore", mock.MatchedBy(func(dbStore *db.FavoriteStore) bool {
 		// UUIDはテストで完全一致が不可能なため、dbStore.id以外のフィールドを検証
-		return dbStore.UserId == 1 &&
+		return dbStore.UserId == "Id001" &&
 			dbStore.StoreId == "Id001" &&
 			dbStore.StoreName == "UEC cafe" &&
 			dbStore.RegularOpeningHours == "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00" &&
@@ -268,7 +268,7 @@ func TestSaveFavoriteStore(t *testing.T) {
 		PriceLevel:          "PRICE_LEVEL_MODERATE",
 		Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 	}
-	userId := 1
+	userId := "Id001"
 
 	/* Act */
 	actual := sg.SaveFavoriteStore(store, userId)

--- a/src/adapter/gateway/user.go
+++ b/src/adapter/gateway/user.go
@@ -4,6 +4,8 @@ import (
 	"clean-storemap-api/src/driver/db"
 	model "clean-storemap-api/src/entity"
 	"clean-storemap-api/src/usecase/port"
+
+	"github.com/google/uuid"
 )
 
 type UserGateway struct {
@@ -14,7 +16,7 @@ type UserGateway struct {
 type UserDriver interface {
 	CreateUser(*db.User) (*db.User, error)
 	UpdateUser(*db.User, map[string]interface{}) error
-	FindById(int) (*db.User, error)
+	FindById(string) (*db.User, error)
 	FindByEmail(string) (*db.User, error)
 }
 
@@ -32,6 +34,7 @@ func NewUserRepository(userDriver UserDriver, googleOAuthDriver GoogleOAuthDrive
 
 func (ug *UserGateway) Create(user *model.User) (*model.User, error) {
 	dbUser := &db.User{
+		Id:     uuid.New().String(),
 		Name:   user.Name,
 		Email:  user.Email,
 		Age:    user.Age,
@@ -70,7 +73,7 @@ func (ug *UserGateway) Update(user *model.User, updateData model.ChangeForUser) 
 	return nil
 }
 
-func (ug *UserGateway) Get(id int) (*model.User, error) {
+func (ug *UserGateway) Get(id string) (*model.User, error) {
 	dbUser, err := ug.userDriver.FindById(id)
 	if err != nil {
 		return nil, err

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -5,6 +5,8 @@ import (
 	model "clean-storemap-api/src/entity"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -13,8 +15,8 @@ type MockUserRepository struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) CreateUser(*db.User) (*db.User, error) {
-	args := m.Called()
+func (m *MockUserRepository) CreateUser(dbUser *db.User) (*db.User, error) {
+	args := m.Called(dbUser)
 	return args.Get(0).(*db.User), args.Error(1)
 }
 
@@ -23,8 +25,8 @@ func (m *MockUserRepository) UpdateUser(*db.User, map[string]interface{}) error 
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) FindById(int) (*db.User, error) {
-	args := m.Called()
+func (m *MockUserRepository) FindById(id string) (*db.User, error) {
+	args := m.Called(id)
 	return args.Get(0).(*db.User), args.Error(1)
 }
 
@@ -42,6 +44,11 @@ func (m *MockUserRepository) GetEmail(string) (string, error) {
 	return args.Get(0).(string), args.Error(1)
 }
 
+func isValidUUID(id string) bool {
+	// 文字列が UUID 形式かを確認
+	_, err := uuid.Parse(id) // UUID を解析し、有効性をチェック
+	return err == nil        // エラーがなければ有効
+}
 func TestCreate(t *testing.T) {
 	/* Arrange */
 	user := &model.User{
@@ -52,7 +59,7 @@ func TestCreate(t *testing.T) {
 		Gender: -0.5,
 	}
 	dbUser := &db.User{
-		Id:     1,
+		Id:     "id_1",
 		Name:   user.Name,
 		Email:  user.Email,
 		Age:    user.Age,
@@ -62,7 +69,14 @@ func TestCreate(t *testing.T) {
 	expected := user
 
 	mockUserRepository := new(MockUserRepository)
-	mockUserRepository.On("CreateUser").Return(dbUser, nil)
+	mockUserRepository.On("CreateUser", mock.MatchedBy(func(dbUser *db.User) bool {
+		return isValidUUID(dbUser.Id) &&
+			dbUser.Name == user.Name &&
+			dbUser.Email == user.Email &&
+			dbUser.Age == user.Age &&
+			dbUser.Sex == user.Sex &&
+			dbUser.Gender == user.Gender
+	})).Return(dbUser, nil)
 	ug := &UserGateway{userDriver: mockUserRepository}
 
 	/* Act */
@@ -99,14 +113,13 @@ func TestExist(t *testing.T) {
 	assert.Equal(t, expected, actual)
 	// userDriver.CreateUser()が1回呼ばれること
 	mockUserRepository.AssertNumberOfCalls(t, "FindByEmail", 1)
-	// mockUserRepository.AssertNumberOfCalls(t, "UpdateUser", 1)
 }
 func TestUpdate(t *testing.T) {
 	/* Arrange */
 	var expected error = nil
 	// 更新されるUser
 	user := &model.User{
-		Id:     1,
+		Id:     "id_1",
 		Name:   "sample",
 		Email:  "sample@example.com",
 		Age:    10,
@@ -130,7 +143,7 @@ func TestUpdate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	/* Arrange */
-	id := 1
+	id := "id_1"
 	dbUser := &db.User{
 		Id:     id,
 		Name:   "sample",
@@ -151,7 +164,7 @@ func TestGet(t *testing.T) {
 	}
 
 	mockUserRepository := new(MockUserRepository)
-	mockUserRepository.On("FindById").Return(dbUser, nil)
+	mockUserRepository.On("FindById", id).Return(dbUser, nil)
 	ug := &UserGateway{userDriver: mockUserRepository}
 
 	/* Act */
@@ -171,13 +184,23 @@ func TestFindBy(t *testing.T) {
 		Email: "noiman@groovex.co.jp",
 	}
 	dbUser := &db.User{
-		Id:     1,
+		Id:     "id_1",
 		Name:   "noiman",
 		Email:  userCredentials.Email,
 		Age:    35,
 		Sex:    1.0,
 		Gender: -0.5,
 	}
+	// mockStoreRepository.On("SaveStore", mock.MatchedBy(func(dbStore *db.FavoriteStore) bool {
+	// 	// UUIDはテストで完全一致が不可能なため、dbStore.id以外のフィールドを検証
+	// 	return dbStore.UserId == 1 &&
+	// 		dbStore.StoreId == "Id001" &&
+	// 		dbStore.StoreName == "UEC cafe" &&
+	// 		dbStore.RegularOpeningHours == "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00" &&
+	// 		dbStore.PriceLevel == "PRICE_LEVEL_MODERATE" &&
+	// 		dbStore.Latitude == "35.713" &&
+	// 		dbStore.Longitude == "139.762"
+	// })).Return(nil)
 	user := &model.User{
 		Id:     dbUser.Id,
 		Name:   dbUser.Name,

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -5,8 +5,6 @@ import (
 	model "clean-storemap-api/src/entity"
 	"testing"
 
-	"github.com/google/uuid"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -44,11 +42,6 @@ func (m *MockUserRepository) GetEmail(string) (string, error) {
 	return args.Get(0).(string), args.Error(1)
 }
 
-func isValidUUID(id string) bool {
-	// 文字列が UUID 形式かを確認
-	_, err := uuid.Parse(id) // UUID を解析し、有効性をチェック
-	return err == nil        // エラーがなければ有効
-}
 func TestCreate(t *testing.T) {
 	/* Arrange */
 	user := &model.User{
@@ -70,8 +63,7 @@ func TestCreate(t *testing.T) {
 
 	mockUserRepository := new(MockUserRepository)
 	mockUserRepository.On("CreateUser", mock.MatchedBy(func(dbUser *db.User) bool {
-		return isValidUUID(dbUser.Id) &&
-			dbUser.Name == user.Name &&
+		return dbUser.Name == user.Name &&
 			dbUser.Email == user.Email &&
 			dbUser.Age == user.Age &&
 			dbUser.Sex == user.Sex &&

--- a/src/adapter/gateway/user_test.go
+++ b/src/adapter/gateway/user_test.go
@@ -191,16 +191,6 @@ func TestFindBy(t *testing.T) {
 		Sex:    1.0,
 		Gender: -0.5,
 	}
-	// mockStoreRepository.On("SaveStore", mock.MatchedBy(func(dbStore *db.FavoriteStore) bool {
-	// 	// UUIDはテストで完全一致が不可能なため、dbStore.id以外のフィールドを検証
-	// 	return dbStore.UserId == 1 &&
-	// 		dbStore.StoreId == "Id001" &&
-	// 		dbStore.StoreName == "UEC cafe" &&
-	// 		dbStore.RegularOpeningHours == "Sat: 06:00 - 22:00, Sun: 06:00 - 22:00" &&
-	// 		dbStore.PriceLevel == "PRICE_LEVEL_MODERATE" &&
-	// 		dbStore.Latitude == "35.713" &&
-	// 		dbStore.Longitude == "139.762"
-	// })).Return(nil)
 	user := &model.User{
 		Id:     dbUser.Id,
 		Name:   dbUser.Name,

--- a/src/adapter/presenter/user.go
+++ b/src/adapter/presenter/user.go
@@ -4,7 +4,6 @@ import (
 	"clean-storemap-api/src/usecase/port"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/labstack/echo/v4"
 )
@@ -25,7 +24,7 @@ func (up *UserPresenter) OutputUpdateResult() error {
 	return up.c.JSON(http.StatusOK, map[string]interface{}{})
 }
 
-func (up *UserPresenter) OutputLoginResult(userId int) error {
+func (up *UserPresenter) OutputLoginResult(userId string) error {
 	return up.c.JSON(http.StatusOK, map[string]interface{}{"userId": userId})
 }
 
@@ -33,8 +32,8 @@ func (up *UserPresenter) OutputAuthUrl(url string) error {
 	return up.c.Redirect(http.StatusFound, url)
 }
 
-func (up *UserPresenter) OutputSignupWithAuth(id int) error {
-	url := os.Getenv("FRONT_URL") + "/editUser" + "?id=" + strconv.Itoa(id) // 認証以外のユーザ情報を入力するページ
+func (up *UserPresenter) OutputSignupWithAuth(id string) error {
+	url := os.Getenv("FRONT_URL") + "/editUser" + "?id=" + id // 認証以外のユーザ情報を入力するページ
 	return up.c.Redirect(http.StatusFound, url)
 }
 

--- a/src/adapter/presenter/user_test.go
+++ b/src/adapter/presenter/user_test.go
@@ -2,7 +2,6 @@ package presenter
 
 import (
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,10 +40,10 @@ func TestOutputUpdateResult(t *testing.T) {
 
 func TestOutputLoginResult(t *testing.T) {
 	/* Arrange */
-	expected := "{\"userId\":1}\n"
+	expected := "{\"userId\":\"id_1\"}\n"
 	c, rec := newRouter()
 	up := &UserPresenter{c: c}
-	userId := 1
+	userId := "id_1"
 
 	/* Act */
 	actual := up.OutputLoginResult(userId)
@@ -75,9 +74,9 @@ func TestOutputAuthUrl(t *testing.T) {
 }
 func TestOutputSignupWithAuth(t *testing.T) {
 	/* Arrange */
-	var id int = 1
+	id := "id_1"
 	requestPath := "/editUser"
-	queryParameter := "id=" + strconv.Itoa(id)
+	queryParameter := "id=" + id
 
 	var expected error = nil
 	c, rec := newRouter()

--- a/src/driver/db/store.go
+++ b/src/driver/db/store.go
@@ -16,7 +16,7 @@ func NewStoreDriver() *DbStoreDriver {
 /* interfaceと型は同義。仮にgatewayがDBの型を知ったとしても、どんなDBから来たかわかるわけではないのでおk */
 type FavoriteStore struct {
 	Id                  string `gorm:"primaryKey"`
-	UserId              int    `gorm:"not null"`
+	UserId              string `gorm:"not null;size:64"`
 	User                User   `gorm:"foreignKey:UserId;references:Id"`
 	StoreId             string `gorm:"not null"`
 	StoreName           string `gorm:"not null"`
@@ -37,7 +37,7 @@ func (dbs *DbStoreDriver) GetStores() ([]*FavoriteStore, error) {
 	return stores, nil
 }
 
-func (dbs *DbStoreDriver) FindFavorite(storeId string, userId int) (*FavoriteStore, error) {
+func (dbs *DbStoreDriver) FindFavorite(storeId string, userId string) (*FavoriteStore, error) {
 	var stores []FavoriteStore
 	err := DB.Where("store_id = ? AND user_id = ?", storeId, userId).Find(&stores).Error
 	if err != nil {
@@ -53,7 +53,7 @@ func (dbs *DbStoreDriver) FindFavorite(storeId string, userId int) (*FavoriteSto
 	return &stores[0], nil
 }
 
-func (dbs *DbStoreDriver) FindFavoriteByUser(userId int) ([]*FavoriteStore, error) {
+func (dbs *DbStoreDriver) FindFavoriteByUser(userId string) ([]*FavoriteStore, error) {
 	var stores []*FavoriteStore
 	err := DB.Where("user_id = ?", userId).Find(&stores).Error
 	if err != nil {

--- a/src/driver/db/user.go
+++ b/src/driver/db/user.go
@@ -53,7 +53,7 @@ func (dbu *DbUserDriver) UpdateUser(user *User, updateData map[string]interface{
 func (dbu *DbUserDriver) FindById(id string) (*User, error) {
 	var user *User
 	// Firstだと存在しない場合にサーバー側でエラーが発生してしまうため、Findでエラーを発生しないようにしている
-	result := DB.Find(&user)
+	result := DB.Find(&user, "id = ?", id)
 	// 存在しない場合にエラーは発生しないので、エラーを作成する
 	if result.RowsAffected == 0 {
 		return nil, errors.New("user is not found")

--- a/src/driver/db/user.go
+++ b/src/driver/db/user.go
@@ -12,7 +12,7 @@ func NewUserDriver() *DbUserDriver {
 }
 
 type User struct {
-	Id        int `gorm:"primaryKey"`
+	Id        string `gorm:"primaryKey"`
 	Name      string
 	Email     string `gorm:"unique"`
 	Age       int
@@ -50,10 +50,10 @@ func (dbu *DbUserDriver) UpdateUser(user *User, updateData map[string]interface{
 	return nil
 }
 
-func (dbu *DbUserDriver) FindById(id int) (*User, error) {
+func (dbu *DbUserDriver) FindById(id string) (*User, error) {
 	var user *User
 	// Firstだと存在しない場合にサーバー側でエラーが発生してしまうため、Findでエラーを発生しないようにしている
-	result := DB.Find(&user, id)
+	result := DB.Find(&user)
 	// 存在しない場合にエラーは発生しないので、エラーを作成する
 	if result.RowsAffected == 0 {
 		return nil, errors.New("user is not found")

--- a/src/entity/user.go
+++ b/src/entity/user.go
@@ -8,7 +8,7 @@ import (
 // type UserId string
 
 type User struct {
-	Id     int // TODO: UserIdに変更したい
+	Id     string // uuidを使用
 	Name   string
 	Email  string
 	Age    int     // xx代として表記する(60代以上は全て60とする)

--- a/src/usecase/interactor/store.go
+++ b/src/usecase/interactor/store.go
@@ -33,7 +33,7 @@ func (si *StoreInteractor) GetNearStores() error {
 	return si.storeOutputPort.OutputAllStores(places)
 }
 
-func (si *StoreInteractor) GetFavoriteStores(userId int) error {
+func (si *StoreInteractor) GetFavoriteStores(userId string) error {
 	stores, err := si.storeRepository.GetFavoriteStores(userId)
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func (si *StoreInteractor) GetFavoriteStores(userId int) error {
 	return si.storeOutputPort.OutputAllStores(stores)
 }
 
-func (si *StoreInteractor) SaveFavoriteStore(store *model.Store, userId int) error {
+func (si *StoreInteractor) SaveFavoriteStore(store *model.Store, userId string) error {
 	exist, err := si.storeRepository.ExistFavorite(store, userId)
 	if err != nil {
 		return err

--- a/src/usecase/interactor/store_test.go
+++ b/src/usecase/interactor/store_test.go
@@ -26,17 +26,17 @@ func (m *MockStoreRepository) GetNearStores() ([]*model.Store, error) {
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepository) ExistFavorite(store *model.Store, userId int) (bool, error) {
+func (m *MockStoreRepository) ExistFavorite(store *model.Store, userId string) (bool, error) {
 	args := m.Called(store, userId)
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockStoreRepository) GetFavoriteStores(userId int) ([]*model.Store, error) {
+func (m *MockStoreRepository) GetFavoriteStores(userId string) ([]*model.Store, error) {
 	args := m.Called(userId)
 	return args.Get(0).([]*model.Store), args.Error(1)
 }
 
-func (m *MockStoreRepository) SaveFavoriteStore(store *model.Store, userId int) error {
+func (m *MockStoreRepository) SaveFavoriteStore(store *model.Store, userId string) error {
 	args := m.Called(store, userId)
 	return args.Error(0)
 }
@@ -142,7 +142,7 @@ func TestGetFavoriteStores(t *testing.T) {
 			Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 		},
 	)
-	userId := 1
+	userId := "Id001"
 
 	mockStoreRepository := new(MockStoreRepository)
 	mockStoreRepository.On("GetFavoriteStores", userId).Return(stores, nil)
@@ -171,7 +171,7 @@ func TestSaveFavoriteStore(t *testing.T) {
 		PriceLevel:          "PRICE_LEVEL_MODERATE",
 		Location:            model.Location{Lat: "35.713", Lng: "139.762"},
 	}
-	userId := 1
+	userId := "Id001"
 
 	mockStoreRepository := new(MockStoreRepository)
 	mockStoreRepository.On("SaveFavoriteStore", store, userId).Return(nil)

--- a/src/usecase/interactor/user.go
+++ b/src/usecase/interactor/user.go
@@ -28,7 +28,7 @@ func (ui *UserInteractor) CreateUser(user *model.User) error {
 	return nil
 }
 
-func (ui *UserInteractor) UpdateUser(id int, updateData model.ChangeForUser) error {
+func (ui *UserInteractor) UpdateUser(id string, updateData model.ChangeForUser) error {
 	// emailを更新しようとした場合にはエラーを返す
 	if _, ok := updateData["email"]; ok {
 		return ui.userOutputPort.OutputHasEmailInRequestBody()
@@ -69,10 +69,7 @@ func (ui *UserInteractor) LoginUser(userCredentials *model.UserCredentials) erro
 	if err != nil {
 		return err
 	}
-	if err := ui.userOutputPort.OutputLoginResult(user.Id); err != nil {
-		return err
-	}
-	return nil
+	return ui.userOutputPort.OutputLoginResult(user.Id)
 }
 
 func (ui *UserInteractor) GetAuthUrl() error {

--- a/src/usecase/port/store.go
+++ b/src/usecase/port/store.go
@@ -7,17 +7,17 @@ import (
 type StoreInputPort interface {
 	GetStores() error
 	GetNearStores() error
-	GetFavoriteStores(userId int) error
-	SaveFavoriteStore(store *model.Store, userId int) error
+	GetFavoriteStores(userId string) error
+	SaveFavoriteStore(store *model.Store, userId string) error
 	GetTopFavoriteStores() error
 }
 
 type StoreRepository interface {
 	GetAll() ([]*model.Store, error)
 	GetNearStores() ([]*model.Store, error)
-	ExistFavorite(store *model.Store, userId int) (bool, error)
-	GetFavoriteStores(userId int) ([]*model.Store, error)
-	SaveFavoriteStore(store *model.Store, userId int) error
+	ExistFavorite(store *model.Store, userId string) (bool, error)
+	GetFavoriteStores(userId string) ([]*model.Store, error)
+	SaveFavoriteStore(store *model.Store, userId string) error
 	GetTopFavoriteStores() ([]*model.Store, error)
 }
 

--- a/src/usecase/port/user.go
+++ b/src/usecase/port/user.go
@@ -6,7 +6,7 @@ import (
 
 type UserInputPort interface {
 	CreateUser(*model.User) error
-	UpdateUser(int, model.ChangeForUser) error
+	UpdateUser(string, model.ChangeForUser) error
 	LoginUser(*model.UserCredentials) error
 	GetAuthUrl() error
 	SignupDraft(string) error
@@ -16,7 +16,7 @@ type UserRepository interface {
 	Exist(*model.User) error
 	Create(*model.User) (*model.User, error)
 	Update(*model.User, model.ChangeForUser) error
-	Get(int) (*model.User, error)
+	Get(string) (*model.User, error)
 	FindBy(*model.UserCredentials) (*model.User, error)
 	GenerateAuthUrl() string
 	GetUserInfoWithAuthCode(string) (string, error)
@@ -25,9 +25,9 @@ type UserRepository interface {
 type UserOutputPort interface {
 	OutputCreateResult() error
 	OutputUpdateResult() error
-	OutputLoginResult(int) error
+	OutputLoginResult(string) error
 	OutputAuthUrl(string) error
-	OutputSignupWithAuth(int) error
+	OutputSignupWithAuth(string) error
 	OutputAlreadySignedup() error
 	OutputHasEmailInRequestBody() error
 }


### PR DESCRIPTION
userのidでuuidに変更しました。
storeの方でもuserIdを使用していたため、storeの方の型も変更しました。
webの方で、受け取ったidをNumber型に変換するコードが含まれているため、そちらを修正しないとエラーが出る箇所があります。[こちら](https://github.com/RinachanBoard31/clean-storemap-web/pull/15)でプルリクを発行したので、確認の際は両方をfetchしていただけたらなと思います。

@RinachanBoard31 
uuidのテストについてstoreのテストと同様の形となりました。🙇
https://github.com/RinachanBoard31/clean-storemap-api/blob/8704151eb2db1e86af6f885c9cc922ddf00bf096/src/adapter/gateway/user_test.go#L72-L79

